### PR TITLE
feat: property graph — MultiDiGraph with typed nodes and edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ uv run ckg --help
 |-------|---------|--------|
 | #5 | Project setup | ✅ Done |
 | #6 | AST parser | ✅ Done |
-| #4 | Property graph | 🔜 Planned |
+| #4 | Property graph | ✅ Done |
 | #2 | DuckDB persistence | 🔜 Planned |
 | #7 | Structural queries | 🔜 Planned |
 | #1 | CLI (full) | 🔜 Planned |

--- a/ckg/graph.py
+++ b/ckg/graph.py
@@ -1,0 +1,300 @@
+"""In-memory property graph backed by networkx MultiDiGraph.
+
+Usage
+-----
+    from ckg.graph import PropertyGraph
+
+    graph = PropertyGraph()
+    graph.build_from_directory("p3/")
+
+    fn = graph.get_node("p3/database.py::add_episode")
+    callers = graph.predecessors("p3/database.py::add_episode", edge_type="CALLS")
+    callees = graph.successors("p3/database.py::add_episode", edge_type="CALLS")
+
+    print(graph.node_count())
+    print(graph.edge_count_by_type())
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterator
+
+import networkx as nx
+
+from ckg.models import (
+    ClassNode,
+    Edge,
+    EdgeType,
+    FileNode,
+    FunctionNode,
+    ModuleNode,
+    Node,
+    ParseResult,
+)
+from ckg.parsers.python import parse_directory, parse_file
+
+
+class PropertyGraph:
+    """A directed property graph over a Python codebase.
+
+    Backed by :class:`networkx.MultiDiGraph` — supports multiple typed
+    edges between the same pair of nodes (e.g. a file that imports a
+    module *and* is defined by it).
+
+    Node data is stored in a flat dict keyed by node ID for O(1) lookup;
+    the networkx graph is used for traversal only.
+    """
+
+    def __init__(self) -> None:
+        self._graph: nx.MultiDiGraph = nx.MultiDiGraph()
+        # id → dataclass instance
+        self._nodes: dict[str, Node] = {}
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def add_node(self, node: Node) -> None:
+        """Add *node* to the graph (idempotent on repeated calls with same id)."""
+        self._nodes[node.id] = node
+        self._graph.add_node(node.id, node_type=node.node_type)
+
+    def add_edge(
+        self,
+        src_id: str,
+        dst_id: str,
+        edge_type: EdgeType,
+        *,
+        line: int | None = None,
+        weight: int = 1,
+        **props,
+    ) -> None:
+        """Add a directed edge *src_id → dst_id* of *edge_type*.
+
+        If either endpoint is not yet in the graph a placeholder node is
+        created so that traversal never raises KeyError.
+        """
+        for nid in (src_id, dst_id):
+            if nid not in self._graph:
+                self._graph.add_node(nid)
+
+        self._graph.add_edge(
+            src_id,
+            dst_id,
+            edge_type=edge_type,
+            line=line,
+            weight=weight,
+            **props,
+        )
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get_node(self, node_id: str) -> Node | None:
+        """Return the typed node for *node_id*, or ``None`` if not found."""
+        return self._nodes.get(node_id)
+
+    def has_node(self, node_id: str) -> bool:
+        return node_id in self._nodes
+
+    # ------------------------------------------------------------------
+    # Typed traversal
+    # ------------------------------------------------------------------
+
+    def successors(
+        self,
+        node_id: str,
+        *,
+        edge_type: EdgeType | None = None,
+    ) -> list[Node]:
+        """Return nodes reachable from *node_id* via one outgoing edge.
+
+        Parameters
+        ----------
+        node_id:
+            Source node ID.
+        edge_type:
+            If given, only edges of this type are followed.
+        """
+        results: list[Node] = []
+        for dst, edge_data_dict in self._graph[node_id].items() if node_id in self._graph else []:
+            for _, data in edge_data_dict.items():
+                if edge_type is None or data.get("edge_type") == edge_type:
+                    if (n := self._nodes.get(dst)) is not None:
+                        results.append(n)
+                    break  # one entry per (src, dst) pair is enough for node list
+        # deduplicate while preserving order
+        seen: set[str] = set()
+        deduped: list[Node] = []
+        for n in results:
+            if n.id not in seen:
+                seen.add(n.id)
+                deduped.append(n)
+        return deduped
+
+    def predecessors(
+        self,
+        node_id: str,
+        *,
+        edge_type: EdgeType | None = None,
+    ) -> list[Node]:
+        """Return nodes that have an edge pointing *to* *node_id*.
+
+        Parameters
+        ----------
+        node_id:
+            Target node ID.
+        edge_type:
+            If given, only edges of this type are considered.
+        """
+        results: list[Node] = []
+        if node_id not in self._graph:
+            return results
+        for src in self._graph.predecessors(node_id):
+            edge_data_dict = self._graph[src][node_id]
+            for _, data in edge_data_dict.items():
+                if edge_type is None or data.get("edge_type") == edge_type:
+                    if (n := self._nodes.get(src)) is not None:
+                        results.append(n)
+                    break
+        seen: set[str] = set()
+        deduped: list[Node] = []
+        for n in results:
+            if n.id not in seen:
+                seen.add(n.id)
+                deduped.append(n)
+        return deduped
+
+    def edges_between(
+        self,
+        src_id: str,
+        dst_id: str,
+        *,
+        edge_type: EdgeType | None = None,
+    ) -> list[dict]:
+        """Return edge attribute dicts for all edges from *src_id* to *dst_id*."""
+        if src_id not in self._graph or dst_id not in self._graph[src_id]:
+            return []
+        return [
+            data
+            for data in self._graph[src_id][dst_id].values()
+            if edge_type is None or data.get("edge_type") == edge_type
+        ]
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def iter_nodes(
+        self, *, node_type: str | None = None
+    ) -> Iterator[Node]:
+        """Iterate over all typed nodes, optionally filtered by *node_type*."""
+        for node in self._nodes.values():
+            if node_type is None or node.node_type == node_type:
+                yield node
+
+    def iter_edges(
+        self, *, edge_type: EdgeType | None = None
+    ) -> Iterator[tuple[str, str, dict]]:
+        """Yield ``(src_id, dst_id, data)`` triples, optionally filtered."""
+        for src, dst, data in self._graph.edges(data=True):
+            if edge_type is None or data.get("edge_type") == edge_type:
+                yield src, dst, data
+
+    # ------------------------------------------------------------------
+    # Statistics
+    # ------------------------------------------------------------------
+
+    def node_count(self, *, node_type: str | None = None) -> int:
+        """Total number of typed nodes (optionally filtered by *node_type*)."""
+        if node_type is None:
+            return len(self._nodes)
+        return sum(1 for n in self._nodes.values() if n.node_type == node_type)
+
+    def edge_count(self, *, edge_type: EdgeType | None = None) -> int:
+        """Total number of edges (optionally filtered by *edge_type*)."""
+        if edge_type is None:
+            return self._graph.number_of_edges()
+        return sum(1 for _, _, d in self._graph.edges(data=True) if d.get("edge_type") == edge_type)
+
+    def edge_count_by_type(self) -> dict[str, int]:
+        """Return a mapping ``{edge_type: count}`` for all edge types present."""
+        counts: dict[str, int] = defaultdict(int)
+        for _, _, data in self._graph.edges(data=True):
+            et = data.get("edge_type", "UNKNOWN")
+            counts[et] += 1
+        return dict(counts)
+
+    def node_count_by_type(self) -> dict[str, int]:
+        """Return a mapping ``{node_type: count}`` for all typed nodes."""
+        counts: dict[str, int] = defaultdict(int)
+        for node in self._nodes.values():
+            counts[node.node_type] += 1
+        return dict(counts)
+
+    # ------------------------------------------------------------------
+    # Build from source
+    # ------------------------------------------------------------------
+
+    def _ingest_parse_result(self, result: ParseResult) -> None:
+        """Add all nodes and edges from one :class:`ParseResult`."""
+        # Nodes
+        self.add_node(result.file_node)
+        for fn in result.functions:
+            self.add_node(fn)
+        for cls in result.classes:
+            self.add_node(cls)
+        for mod in result.modules:
+            self.add_node(mod)
+
+        # Edges
+        for edge in result.edges:
+            self.add_edge(
+                edge.src_id,
+                edge.dst_id,
+                edge.edge_type,
+                line=edge.line,
+                weight=edge.weight,
+            )
+
+    def build_from_parse_results(self, results: list[ParseResult]) -> None:
+        """Populate the graph from a pre-computed list of parse results."""
+        for result in results:
+            self._ingest_parse_result(result)
+
+    def build_from_file(
+        self, path: Path | str, project_root: Path | str
+    ) -> None:
+        """Parse a single file and add its nodes/edges to the graph."""
+        result = parse_file(path, project_root)
+        self._ingest_parse_result(result)
+
+    def build_from_directory(self, root: Path | str) -> None:
+        """Recursively parse all ``.py`` files under *root* and build the graph."""
+        results = parse_directory(root)
+        self.build_from_parse_results(results)
+
+    # ------------------------------------------------------------------
+    # NetworkX passthrough (for queries that need raw graph access)
+    # ------------------------------------------------------------------
+
+    @property
+    def nx_graph(self) -> nx.MultiDiGraph:
+        """Direct access to the underlying :class:`networkx.MultiDiGraph`."""
+        return self._graph
+
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:  # pragma: no cover
+        by_type = self.node_count_by_type()
+        by_edge = self.edge_count_by_type()
+        return (
+            f"PropertyGraph("
+            f"nodes={self.node_count()} {dict(by_type)}, "
+            f"edges={self.edge_count()} {dict(by_edge)})"
+        )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,350 @@
+"""Tests for ckg.graph.PropertyGraph."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode, Edge, ParseResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fn(id: str, name: str = "fn", file_path: str = "a.py") -> FunctionNode:
+    return FunctionNode(
+        id=id, name=name, file_path=file_path,
+        line_start=1, line_end=5, signature=f"def {name}()",
+        docstring=None, return_type=None,
+        cyclomatic_complexity=1, is_async=False,
+        is_method=False, class_name=None,
+    )
+
+
+def _file(path: str = "a.py") -> FileNode:
+    return FileNode(id=path, path=path, line_count=10)
+
+
+def _mod(name: str = "os") -> ModuleNode:
+    return ModuleNode(id=name, name=name, is_stdlib=True, is_local=False)
+
+
+def _edge(src: str, dst: str, etype: str = "CALLS", line: int = 1) -> Edge:
+    return Edge(src_id=src, dst_id=dst, edge_type=etype, line=line)  # type: ignore[arg-type]
+
+
+def _make_source(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(source))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# add_node / get_node
+# ---------------------------------------------------------------------------
+
+class TestAddGetNode:
+    def test_get_node_returns_dataclass(self) -> None:
+        g = PropertyGraph()
+        fn = _fn("a.py::foo")
+        g.add_node(fn)
+        assert g.get_node("a.py::foo") is fn
+
+    def test_get_node_missing_returns_none(self) -> None:
+        g = PropertyGraph()
+        assert g.get_node("nope") is None
+
+    def test_add_node_idempotent(self) -> None:
+        g = PropertyGraph()
+        fn1 = _fn("a.py::foo")
+        fn2 = _fn("a.py::foo")
+        g.add_node(fn1)
+        g.add_node(fn2)
+        assert g.node_count() == 1
+
+    def test_different_node_types(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_mod("os"))
+        assert g.node_count() == 3
+
+
+# ---------------------------------------------------------------------------
+# add_edge
+# ---------------------------------------------------------------------------
+
+class TestAddEdge:
+    def test_edge_added(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        g.add_edge("a.py::foo", "a.py::bar", "CALLS")
+        assert g.edge_count() == 1
+
+    def test_edge_creates_placeholder_nodes(self) -> None:
+        """Endpoints that are not typed nodes should still allow traversal."""
+        g = PropertyGraph()
+        g.add_edge("unknown_src", "unknown_dst", "IMPORTS")
+        assert g.edge_count() == 1
+
+    def test_multiple_edge_types_between_same_pair(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        g.add_edge("a.py::foo", "a.py::bar", "CALLS")
+        g.add_edge("a.py::foo", "a.py::bar", "DEFINES")
+        assert g.edge_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# successors / predecessors
+# ---------------------------------------------------------------------------
+
+class TestTraversal:
+    def _graph_with_calls(self) -> PropertyGraph:
+        g = PropertyGraph()
+        foo = _fn("a.py::foo", name="foo")
+        bar = _fn("a.py::bar", name="bar")
+        baz = _fn("a.py::baz", name="baz")
+        for n in (foo, bar, baz):
+            g.add_node(n)
+        g.add_edge("a.py::foo", "a.py::bar", "CALLS")
+        g.add_edge("a.py::foo", "a.py::baz", "CALLS")
+        g.add_edge("a.py::bar", "a.py::baz", "CALLS")
+        return g
+
+    def test_successors_unfiltered(self) -> None:
+        g = self._graph_with_calls()
+        result = g.successors("a.py::foo")
+        ids = {n.id for n in result}
+        assert ids == {"a.py::bar", "a.py::baz"}
+
+    def test_successors_filtered_by_type(self) -> None:
+        g = self._graph_with_calls()
+        g.add_node(_file("a.py"))
+        g.add_edge("a.py", "a.py::foo", "DEFINES")
+        g.add_edge("a.py", "a.py::bar", "DEFINES")
+        calls = g.successors("a.py::foo", edge_type="CALLS")
+        defines = g.successors("a.py", edge_type="DEFINES")
+        assert {n.id for n in calls} == {"a.py::bar", "a.py::baz"}
+        assert {n.id for n in defines} == {"a.py::foo", "a.py::bar"}
+
+    def test_predecessors_unfiltered(self) -> None:
+        g = self._graph_with_calls()
+        result = g.predecessors("a.py::baz")
+        ids = {n.id for n in result}
+        assert ids == {"a.py::foo", "a.py::bar"}
+
+    def test_predecessors_filtered(self) -> None:
+        g = self._graph_with_calls()
+        result = g.predecessors("a.py::bar", edge_type="CALLS")
+        assert len(result) == 1
+        assert result[0].id == "a.py::foo"
+
+    def test_successors_unknown_node_returns_empty(self) -> None:
+        g = PropertyGraph()
+        assert g.successors("nope") == []
+
+    def test_predecessors_unknown_node_returns_empty(self) -> None:
+        g = PropertyGraph()
+        assert g.predecessors("nope") == []
+
+    def test_successors_deduplicates(self) -> None:
+        """Two edges of different types to same dst → node appears once."""
+        g = PropertyGraph()
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        g.add_edge("a.py::foo", "a.py::bar", "CALLS")
+        g.add_edge("a.py::foo", "a.py::bar", "DEFINES")
+        result = g.successors("a.py::foo")
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# edges_between
+# ---------------------------------------------------------------------------
+
+class TestEdgesBetween:
+    def test_returns_edge_data(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS", line=10, weight=2)
+        edges = g.edges_between("a", "b")
+        assert len(edges) == 1
+        assert edges[0]["edge_type"] == "CALLS"
+        assert edges[0]["line"] == 10
+        assert edges[0]["weight"] == 2
+
+    def test_filtered_by_type(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("a", "b", "IMPORTS")
+        calls = g.edges_between("a", "b", edge_type="CALLS")
+        assert len(calls) == 1
+        assert calls[0]["edge_type"] == "CALLS"
+
+    def test_missing_pair_returns_empty(self) -> None:
+        g = PropertyGraph()
+        assert g.edges_between("x", "y") == []
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+class TestStatistics:
+    def test_node_count_total(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        assert g.node_count() == 3
+
+    def test_node_count_by_type_filter(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        assert g.node_count(node_type="function") == 2
+        assert g.node_count(node_type="file") == 1
+
+    def test_edge_count_total(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("a", "c", "IMPORTS")
+        assert g.edge_count() == 2
+
+    def test_edge_count_filtered(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("a", "c", "CALLS")
+        g.add_edge("a", "d", "IMPORTS")
+        assert g.edge_count(edge_type="CALLS") == 2
+        assert g.edge_count(edge_type="IMPORTS") == 1
+
+    def test_edge_count_by_type(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("c", "d", "IMPORTS")
+        g.add_edge("e", "f", "DEFINES")
+        counts = g.edge_count_by_type()
+        assert counts["CALLS"] == 1
+        assert counts["IMPORTS"] == 1
+        assert counts["DEFINES"] == 1
+
+    def test_node_count_by_type(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_mod("os"))
+        by_type = g.node_count_by_type()
+        assert by_type["file"] == 1
+        assert by_type["function"] == 1
+        assert by_type["module"] == 1
+
+
+# ---------------------------------------------------------------------------
+# iter_nodes / iter_edges
+# ---------------------------------------------------------------------------
+
+class TestIteration:
+    def test_iter_nodes_all(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        assert len(list(g.iter_nodes())) == 2
+
+    def test_iter_nodes_filtered(self) -> None:
+        g = PropertyGraph()
+        g.add_node(_file("a.py"))
+        g.add_node(_fn("a.py::foo"))
+        g.add_node(_fn("a.py::bar"))
+        fns = list(g.iter_nodes(node_type="function"))
+        assert len(fns) == 2
+
+    def test_iter_edges_all(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("c", "d", "IMPORTS")
+        assert len(list(g.iter_edges())) == 2
+
+    def test_iter_edges_filtered(self) -> None:
+        g = PropertyGraph()
+        g.add_edge("a", "b", "CALLS")
+        g.add_edge("c", "d", "IMPORTS")
+        calls = list(g.iter_edges(edge_type="CALLS"))
+        assert len(calls) == 1
+        assert calls[0][2]["edge_type"] == "CALLS"
+
+
+# ---------------------------------------------------------------------------
+# build_from_directory (integration)
+# ---------------------------------------------------------------------------
+
+class TestBuildFromDirectory:
+    def test_parses_py_files(self, tmp_path: Path) -> None:
+        _make_source(tmp_path, "a.py", """\
+            import os
+
+            def foo(x: int) -> int:
+                return x + 1
+        """)
+        _make_source(tmp_path, "b.py", """\
+            from a import foo
+
+            class Bar:
+                def method(self) -> None:
+                    foo(1)
+        """)
+        g = PropertyGraph()
+        g.build_from_directory(tmp_path)
+
+        assert g.node_count() > 0
+        assert g.node_count(node_type="function") >= 2
+        assert g.node_count(node_type="class") >= 1
+        assert g.edge_count(edge_type="IMPORTS") >= 2
+        assert g.edge_count(edge_type="DEFINES") >= 2
+        assert g.edge_count(edge_type="CALLS") >= 1
+
+    def test_edge_count_by_type_has_expected_keys(self, tmp_path: Path) -> None:
+        _make_source(tmp_path, "a.py", """\
+            import os
+
+            def foo(): pass
+            def bar(): foo()
+        """)
+        g = PropertyGraph()
+        g.build_from_directory(tmp_path)
+        by_type = g.edge_count_by_type()
+        assert "IMPORTS" in by_type
+        assert "DEFINES" in by_type
+        assert "CALLS" in by_type
+
+    def test_get_node_by_id_after_build(self, tmp_path: Path) -> None:
+        _make_source(tmp_path, "mod.py", "def greet(name): pass\n")
+        g = PropertyGraph()
+        g.build_from_directory(tmp_path)
+        node = g.get_node("mod.py::greet")
+        assert node is not None
+        assert isinstance(node, FunctionNode)
+        assert node.name == "greet"
+
+    def test_nx_graph_accessible(self, tmp_path: Path) -> None:
+        _make_source(tmp_path, "a.py", "def foo(): pass\n")
+        g = PropertyGraph()
+        g.build_from_directory(tmp_path)
+        import networkx as nx
+        assert isinstance(g.nx_graph, nx.MultiDiGraph)
+        assert g.nx_graph.number_of_nodes() > 0
+
+    def test_build_from_parse_results(self, tmp_path: Path) -> None:
+        from ckg.parsers.python import parse_directory
+        _make_source(tmp_path, "a.py", "def foo(): pass\n")
+        results = parse_directory(tmp_path)
+        g = PropertyGraph()
+        g.build_from_parse_results(results)
+        assert g.node_count() > 0


### PR DESCRIPTION
## Summary

Implements issue #4 — in-memory property graph backed by `networkx.MultiDiGraph`.

## New files

| File | Purpose |
|---|---|
| `ckg/graph.py` | `PropertyGraph` — typed node/edge storage + traversal |
| `tests/test_graph.py` | 32 unit tests |

## API

```python
from ckg.graph import PropertyGraph

g = PropertyGraph()
g.build_from_directory('my_project/')

# O(1) node lookup
fn = g.get_node('database.py::add_episode')   # → FunctionNode

# Typed traversal
callers  = g.predecessors('database.py::add_episode', edge_type='CALLS')
callees  = g.successors('database.py::add_episode',   edge_type='CALLS')

# Statistics
g.node_count()                 # total
g.node_count(node_type='function')
g.edge_count_by_type()         # {'CALLS': 42, 'IMPORTS': 18, 'DEFINES': 55, ...}
```

## Design notes

- **MultiDiGraph** — supports multiple typed edges between the same pair of nodes (e.g. CALLS + DEFINES)
- **Dual storage** — typed dataclasses in `_nodes` dict for O(1) lookup; networkx used purely for traversal
- **Placeholder nodes** — `add_edge` auto-creates stub graph nodes for unresolved endpoints (e.g. third-party module names) so traversal never raises KeyError
- **`nx_graph` property** — raw networkx access exposed for upcoming structural queries (#7) that need `nx.shortest_path`, BFS, etc.

## Tests

32 new tests + 28 existing parser tests = **60 total, all passing**

## Next

Issue #7 (structural queries) and #2 (DuckDB persistence) are both now unblocked.