### PR TITLE
feat: structural queries — impact_radius, fan_in, dead_code, hotspots

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ uv run ckg --help
 | #6 | AST parser | ✅ Done |
 | #4 | Property graph | ✅ Done |
 | #2 | DuckDB persistence | 🔜 Planned |
-| #7 | Structural queries | 🔜 Planned |
+| #7 | Structural queries | ✅ Done |
 | #1 | CLI (full) | 🔜 Planned |
 | #3 | Eval on P³ | 🔜 Planned |

--- a/ckg/queries.py
+++ b/ckg/queries.py
@@ -1,0 +1,365 @@
+"""Structural queries over a PropertyGraph.
+
+These answer real engineering questions that flat text search cannot:
+
+    from ckg.graph import PropertyGraph
+    from ckg.queries import GraphQueries
+
+    g = PropertyGraph()
+    g.build_from_directory("my_project/")
+    q = GraphQueries(g)
+
+    q.impact_radius("database.py::add_episode", depth=3)
+    q.fan_in(top_k=10)
+    q.uncalled_functions()
+    q.complexity_hotspots(top_k=10)
+    q.dependency_path("cli.py", "database.py")
+    q.raises_exception("ValueError")
+    q.callers("add_episode")
+    q.callees("add_episode")
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING
+
+import networkx as nx
+
+from ckg.models import FunctionNode, FileNode, Node
+
+if TYPE_CHECKING:
+    from ckg.graph import PropertyGraph
+
+# Functions excluded from "uncalled" analysis — entry points / magic methods
+# that are legitimately never called from within the codebase itself.
+_UNCALLED_EXCLUDE: frozenset[str] = frozenset(
+    {
+        "__init__",
+        "__new__",
+        "__del__",
+        "__repr__",
+        "__str__",
+        "__len__",
+        "__getitem__",
+        "__setitem__",
+        "__delitem__",
+        "__contains__",
+        "__iter__",
+        "__next__",
+        "__enter__",
+        "__exit__",
+        "__eq__",
+        "__hash__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+        "__add__",
+        "__sub__",
+        "__mul__",
+        "__truediv__",
+        "__call__",
+        "__class_getitem__",
+        "main",  # CLI entry points
+        "setup",
+        "teardown",
+        # pytest conventions
+        "test_",  # prefix — checked separately
+    }
+)
+
+
+def _is_excluded_from_uncalled(fn: FunctionNode) -> bool:
+    """Return True if *fn* should be excluded from the uncalled-functions list."""
+    name = fn.name
+    # dunder methods
+    if name.startswith("__") and name.endswith("__"):
+        return True
+    # pytest test functions / methods
+    if name.startswith("test_") or name.startswith("Test"):
+        return True
+    # explicit exclude list
+    if name in _UNCALLED_EXCLUDE:
+        return True
+    return False
+
+
+class GraphQueries:
+    """Named structural queries over a :class:`~ckg.graph.PropertyGraph`."""
+
+    def __init__(self, graph: "PropertyGraph") -> None:
+        self._g = graph
+
+    # ------------------------------------------------------------------
+    # 1. Impact radius
+    # ------------------------------------------------------------------
+
+    def impact_radius(
+        self,
+        node_id: str,
+        *,
+        depth: int = 3,
+    ) -> dict[int, list[FunctionNode]]:
+        """BFS over CALLS *predecessors* up to *depth* hops.
+
+        Returns a dict mapping distance → list of FunctionNodes at that
+        distance.  Distance 1 = direct callers, 2 = their callers, etc.
+
+        Parameters
+        ----------
+        node_id:
+            Full node ID of the function whose impact you want to measure.
+            Accepts a bare function name and will resolve it if unambiguous.
+        depth:
+            Maximum BFS depth (default 3).
+        """
+        node_id = self._resolve_id(node_id)
+        result: dict[int, list[FunctionNode]] = {}
+
+        visited: set[str] = {node_id}
+        frontier: set[str] = {node_id}
+
+        for d in range(1, depth + 1):
+            next_frontier: set[str] = set()
+            for nid in frontier:
+                for src, _, data in self._g.nx_graph.in_edges(nid, data=True):
+                    if data.get("edge_type") == "CALLS" and src not in visited:
+                        next_frontier.add(src)
+                        visited.add(src)
+            if not next_frontier:
+                break
+            frontier = next_frontier  # advance BFS wave
+            layer: list[FunctionNode] = []
+            for nid in sorted(next_frontier):
+                node = self._g.get_node(nid)
+                if isinstance(node, FunctionNode):
+                    layer.append(node)
+            if layer:
+                result[d] = layer
+
+        return result
+
+    # ------------------------------------------------------------------
+    # 2. Fan-in  (most-called functions)
+    # ------------------------------------------------------------------
+
+    def fan_in(self, *, top_k: int = 10) -> list[tuple[FunctionNode, int]]:
+        """Return the *top_k* functions with the most distinct callers.
+
+        Returns a list of ``(FunctionNode, caller_count)`` tuples sorted
+        descending by caller count.
+        """
+        counts: dict[str, int] = {}
+        for nid, node in self._g._nodes.items():
+            if not isinstance(node, FunctionNode):
+                continue
+            caller_count = sum(
+                1
+                for _, _, data in self._g.nx_graph.in_edges(nid, data=True)
+                if data.get("edge_type") == "CALLS"
+            )
+            counts[nid] = caller_count
+
+        ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top_k]
+        return [
+            (self._g.get_node(nid), cnt)  # type: ignore[misc]
+            for nid, cnt in ranked
+            if self._g.get_node(nid) is not None
+        ]
+
+    # ------------------------------------------------------------------
+    # 3. Uncalled functions  (dead code candidates)
+    # ------------------------------------------------------------------
+
+    def uncalled_functions(self) -> list[FunctionNode]:
+        """Return functions with zero CALLS-predecessors inside the graph.
+
+        Excludes dunder methods, ``main``, pytest entry points, and other
+        functions that are legitimately never called from within the
+        codebase itself.
+        """
+        result: list[FunctionNode] = []
+        for nid, node in self._g._nodes.items():
+            if not isinstance(node, FunctionNode):
+                continue
+            if _is_excluded_from_uncalled(node):
+                continue
+            caller_count = sum(
+                1
+                for _, _, data in self._g.nx_graph.in_edges(nid, data=True)
+                if data.get("edge_type") == "CALLS"
+            )
+            if caller_count == 0:
+                result.append(node)
+
+        return sorted(result, key=lambda fn: (fn.file_path, fn.name))
+
+    # ------------------------------------------------------------------
+    # 4. Complexity hotspots
+    # ------------------------------------------------------------------
+
+    def complexity_hotspots(
+        self, *, top_k: int = 10
+    ) -> list[tuple[FunctionNode, int]]:
+        """Return the *top_k* functions ranked by cyclomatic complexity (desc).
+
+        Returns a list of ``(FunctionNode, complexity)`` tuples.
+        """
+        fns = [
+            (node, node.cyclomatic_complexity)
+            for node in self._g._nodes.values()
+            if isinstance(node, FunctionNode)
+        ]
+        fns.sort(key=lambda t: t[1], reverse=True)
+        return fns[:top_k]
+
+    # ------------------------------------------------------------------
+    # 5. Dependency path  (file-level shortest path via IMPORTS)
+    # ------------------------------------------------------------------
+
+    def dependency_path(
+        self, src_file: str, dst_file: str
+    ) -> list[str] | None:
+        """Return the shortest IMPORTS-edge path from *src_file* to *dst_file*.
+
+        Returns a list of file/module IDs representing the path, or
+        ``None`` if no path exists.
+
+        Accepts relative file paths (e.g. ``cli.py``) or bare module names.
+        The parser emits IMPORTS edges whose destination is the module name
+        (e.g. ``service``), so this method tries to resolve a ``.py`` filename
+        to its bare module name when looking up the destination node.
+        """
+        # Build a simple DiGraph of IMPORTS edges only (faster for path search)
+        imports_view = nx.DiGraph(
+            (src, dst)
+            for src, dst, data in self._g.nx_graph.edges(data=True)
+            if data.get("edge_type") == "IMPORTS"
+        )
+
+        # Resolve file paths → best reachable node ID.
+        # The parser emits IMPORTS edges whose destination is the module name
+        # (e.g. "service"), not the file path (e.g. "service.py").
+        # So for a given "service.py" argument we try both forms and pick
+        # whichever has the most in-edges (i.e. is actually a dependency target).
+        def _resolve(name: str) -> str:
+            stem = name[:-3] if name.endswith(".py") else name
+            candidates = [name, stem]
+            # prefer the candidate that appears as a destination of IMPORTS edges
+            for c in candidates:
+                if imports_view.in_degree(c) > 0 if c in imports_view else False:
+                    return c
+            # fallback: first candidate present in graph
+            for c in candidates:
+                if c in imports_view:
+                    return c
+            return name
+
+        src = _resolve(src_file)
+        dst = _resolve(dst_file)
+
+        if src not in imports_view or dst not in imports_view:
+            return None
+
+        try:
+            return nx.shortest_path(imports_view, src, dst)
+        except nx.NetworkXNoPath:
+            return None
+        except nx.NodeNotFound:
+            return None
+
+    # ------------------------------------------------------------------
+    # 6. Raises exception
+    # ------------------------------------------------------------------
+
+    def raises_exception(self, exception_name: str) -> list[FunctionNode]:
+        """Return all functions that raise *exception_name*.
+
+        Matches the destination of RAISES edges by exact name.
+        """
+        result: list[FunctionNode] = []
+        for src, dst, data in self._g.nx_graph.edges(data=True):
+            if data.get("edge_type") != "RAISES":
+                continue
+            if dst != exception_name:
+                continue
+            node = self._g.get_node(src)
+            if isinstance(node, FunctionNode):
+                result.append(node)
+        return sorted(result, key=lambda fn: fn.id)
+
+    # ------------------------------------------------------------------
+    # 7. Callers / callees  (by name or full ID)
+    # ------------------------------------------------------------------
+
+    def callers(self, name_or_id: str) -> list[FunctionNode]:
+        """Return all functions that call *name_or_id*.
+
+        Accepts a bare name (resolved if unambiguous) or a full node ID.
+        """
+        node_id = self._resolve_id(name_or_id)
+        return [
+            n for n in self._g.predecessors(node_id, edge_type="CALLS")
+            if isinstance(n, FunctionNode)
+        ]
+
+    def callees(self, name_or_id: str) -> list[FunctionNode]:
+        """Return all functions called by *name_or_id*.
+
+        Accepts a bare name (resolved if unambiguous) or a full node ID.
+        """
+        node_id = self._resolve_id(name_or_id)
+        return [
+            n for n in self._g.successors(node_id, edge_type="CALLS")
+            if isinstance(n, FunctionNode)
+        ]
+
+    # ------------------------------------------------------------------
+    # 8. File fan-in  (most-imported files)
+    # ------------------------------------------------------------------
+
+    def file_fan_in(self, *, top_k: int = 10) -> list[tuple[FileNode, int]]:
+        """Return the *top_k* files imported by the most other files (desc)."""
+        counts: dict[str, int] = {}
+        for nid, node in self._g._nodes.items():
+            if not isinstance(node, FileNode):
+                continue
+            count = sum(
+                1
+                for _, _, data in self._g.nx_graph.in_edges(nid, data=True)
+                if data.get("edge_type") == "IMPORTS"
+            )
+            counts[nid] = count
+
+        ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top_k]
+        return [
+            (self._g.get_node(nid), cnt)  # type: ignore[misc]
+            for nid, cnt in ranked
+            if self._g.get_node(nid) is not None
+        ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_id(self, name_or_id: str) -> str:
+        """Resolve a bare function name to a full node ID if unambiguous.
+
+        If *name_or_id* already exists as a node ID it is returned as-is.
+        Otherwise all FunctionNodes whose ``name`` matches are collected;
+        if exactly one match exists that ID is returned, otherwise the
+        original string is returned unchanged (traversal will just find
+        nothing, which is safe).
+        """
+        if self._g.has_node(name_or_id):
+            return name_or_id
+
+        matches = [
+            nid
+            for nid, node in self._g._nodes.items()
+            if isinstance(node, FunctionNode) and node.name == name_or_id
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        return name_or_id

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,460 @@
+"""Tests for ckg.queries.GraphQueries."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, FileNode
+from ckg.queries import GraphQueries
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_source(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(source))
+    return p
+
+
+def _fn(g: PropertyGraph, id: str, name: str, file_path: str = "a.py",
+        complexity: int = 1, is_method: bool = False,
+        class_name: str | None = None) -> FunctionNode:
+    node = FunctionNode(
+        id=id, name=name, file_path=file_path,
+        line_start=1, line_end=5, signature=f"def {name}()",
+        docstring=None, return_type=None,
+        cyclomatic_complexity=complexity, is_async=False,
+        is_method=is_method, class_name=class_name,
+    )
+    g.add_node(node)
+    return node
+
+
+def _file(g: PropertyGraph, path: str) -> FileNode:
+    node = FileNode(id=path, path=path, line_count=10)
+    g.add_node(node)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# impact_radius
+# ---------------------------------------------------------------------------
+
+class TestImpactRadius:
+    def _make_call_chain(self) -> PropertyGraph:
+        """
+        d calls c, c calls b, b calls a  (a is the deepest dependency)
+        query: impact_radius('a') should return b at d=1, c at d=2, d at d=3
+        """
+        g = PropertyGraph()
+        a = _fn(g, "f.py::a", "a")
+        b = _fn(g, "f.py::b", "b")
+        c = _fn(g, "f.py::c", "c")
+        d = _fn(g, "f.py::d", "d")
+        g.add_edge("f.py::b", "f.py::a", "CALLS")
+        g.add_edge("f.py::c", "f.py::b", "CALLS")
+        g.add_edge("f.py::d", "f.py::c", "CALLS")
+        return g
+
+    def test_direct_callers_at_depth_1(self) -> None:
+        g = self._make_call_chain()
+        q = GraphQueries(g)
+        result = q.impact_radius("f.py::a", depth=3)
+        assert 1 in result
+        assert any(fn.name == "b" for fn in result[1])
+
+    def test_transitive_callers_at_depth_2(self) -> None:
+        g = self._make_call_chain()
+        q = GraphQueries(g)
+        result = q.impact_radius("f.py::a", depth=3)
+        assert 2 in result
+        assert any(fn.name == "c" for fn in result[2])
+
+    def test_depth_limit_respected(self) -> None:
+        g = self._make_call_chain()
+        q = GraphQueries(g)
+        result = q.impact_radius("f.py::a", depth=1)
+        assert 1 in result
+        assert 2 not in result
+
+    def test_no_callers_returns_empty(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::lonely", "lonely")
+        q = GraphQueries(g)
+        assert q.impact_radius("f.py::lonely") == {}
+
+    def test_resolves_bare_name(self) -> None:
+        g = self._make_call_chain()
+        q = GraphQueries(g)
+        result = q.impact_radius("a", depth=1)
+        assert 1 in result
+
+    def test_diamond_deduplicates(self) -> None:
+        """Two paths to a — each caller counted only once."""
+        g = PropertyGraph()
+        _fn(g, "f.py::a", "a")
+        _fn(g, "f.py::b", "b")
+        _fn(g, "f.py::c", "c")
+        _fn(g, "f.py::d", "d")
+        g.add_edge("f.py::b", "f.py::a", "CALLS")
+        g.add_edge("f.py::c", "f.py::a", "CALLS")
+        g.add_edge("f.py::d", "f.py::b", "CALLS")
+        g.add_edge("f.py::d", "f.py::c", "CALLS")
+        q = GraphQueries(g)
+        result = q.impact_radius("f.py::a", depth=3)
+        # d appears at depth 2 only once
+        d_nodes = [fn for layer in result.values() for fn in layer if fn.name == "d"]
+        assert len(d_nodes) == 1
+
+
+# ---------------------------------------------------------------------------
+# fan_in
+# ---------------------------------------------------------------------------
+
+class TestFanIn:
+    def test_most_called_first(self) -> None:
+        g = PropertyGraph()
+        popular  = _fn(g, "f.py::popular",  "popular")
+        caller1  = _fn(g, "f.py::caller1",  "caller1")
+        caller2  = _fn(g, "f.py::caller2",  "caller2")
+        caller3  = _fn(g, "f.py::caller3",  "caller3")
+        loner    = _fn(g, "f.py::loner",    "loner")
+        for src in ("f.py::caller1", "f.py::caller2", "f.py::caller3"):
+            g.add_edge(src, "f.py::popular", "CALLS")
+
+        q = GraphQueries(g)
+        result = q.fan_in(top_k=3)
+        assert result[0][0].name == "popular"
+        assert result[0][1] == 3
+
+    def test_top_k_limits_results(self) -> None:
+        g = PropertyGraph()
+        for i in range(10):
+            _fn(g, f"f.py::fn{i}", f"fn{i}")
+        q = GraphQueries(g)
+        assert len(q.fan_in(top_k=3)) == 3
+
+    def test_zero_callers_included(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::unused", "unused")
+        q = GraphQueries(g)
+        result = q.fan_in(top_k=5)
+        assert any(fn.name == "unused" and cnt == 0 for fn, cnt in result)
+
+
+# ---------------------------------------------------------------------------
+# uncalled_functions
+# ---------------------------------------------------------------------------
+
+class TestUncalledFunctions:
+    def test_finds_unused_function(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::used",   "used")
+        _fn(g, "f.py::unused", "unused")
+        _fn(g, "f.py::caller", "caller")
+        g.add_edge("f.py::caller", "f.py::used", "CALLS")
+        q = GraphQueries(g)
+        result = q.uncalled_functions()
+        names = {fn.name for fn in result}
+        assert "unused" in names
+        assert "used" not in names
+
+    def test_excludes_dunder_methods(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::__init__", "__init__", is_method=True, class_name="Foo")
+        _fn(g, "f.py::__str__",  "__str__",  is_method=True, class_name="Foo")
+        q = GraphQueries(g)
+        result = q.uncalled_functions()
+        names = {fn.name for fn in result}
+        assert "__init__" not in names
+        assert "__str__" not in names
+
+    def test_excludes_main(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::main", "main")
+        q = GraphQueries(g)
+        result = q.uncalled_functions()
+        assert not any(fn.name == "main" for fn in result)
+
+    def test_excludes_test_functions(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "t.py::test_foo", "test_foo")
+        q = GraphQueries(g)
+        result = q.uncalled_functions()
+        assert not any(fn.name == "test_foo" for fn in result)
+
+    def test_result_sorted_by_file_then_name(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "b.py::z", "z", file_path="b.py")
+        _fn(g, "a.py::m", "m", file_path="a.py")
+        _fn(g, "a.py::a", "a", file_path="a.py")
+        q = GraphQueries(g)
+        result = q.uncalled_functions()
+        keys = [(fn.file_path, fn.name) for fn in result]
+        assert keys == sorted(keys)
+
+
+# ---------------------------------------------------------------------------
+# complexity_hotspots
+# ---------------------------------------------------------------------------
+
+class TestComplexityHotspots:
+    def test_highest_complexity_first(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::simple",  "simple",  complexity=1)
+        _fn(g, "f.py::medium",  "medium",  complexity=5)
+        _fn(g, "f.py::complex", "complex", complexity=12)
+        q = GraphQueries(g)
+        result = q.complexity_hotspots(top_k=3)
+        assert result[0][0].name == "complex"
+        assert result[0][1] == 12
+
+    def test_top_k_respected(self) -> None:
+        g = PropertyGraph()
+        for i in range(10):
+            _fn(g, f"f.py::fn{i}", f"fn{i}", complexity=i)
+        q = GraphQueries(g)
+        assert len(q.complexity_hotspots(top_k=3)) == 3
+
+    def test_returns_function_and_complexity(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::foo", "foo", complexity=7)
+        q = GraphQueries(g)
+        fn, complexity = q.complexity_hotspots(top_k=1)[0]
+        assert isinstance(fn, FunctionNode)
+        assert complexity == 7
+
+
+# ---------------------------------------------------------------------------
+# dependency_path
+# ---------------------------------------------------------------------------
+
+class TestDependencyPath:
+    def _graph_with_imports(self) -> PropertyGraph:
+        g = PropertyGraph()
+        for p in ("a.py", "b.py", "c.py"):
+            _file(g, p)
+        g.add_edge("a.py", "b.py", "IMPORTS")
+        g.add_edge("b.py", "c.py", "IMPORTS")
+        return g
+
+    def test_direct_path(self) -> None:
+        g = self._graph_with_imports()
+        q = GraphQueries(g)
+        path = q.dependency_path("a.py", "b.py")
+        assert path == ["a.py", "b.py"]
+
+    def test_transitive_path(self) -> None:
+        g = self._graph_with_imports()
+        q = GraphQueries(g)
+        path = q.dependency_path("a.py", "c.py")
+        assert path == ["a.py", "b.py", "c.py"]
+
+    def test_no_path_returns_none(self) -> None:
+        g = self._graph_with_imports()
+        q = GraphQueries(g)
+        assert q.dependency_path("c.py", "a.py") is None
+
+    def test_missing_node_returns_none(self) -> None:
+        g = self._graph_with_imports()
+        q = GraphQueries(g)
+        assert q.dependency_path("a.py", "nonexistent.py") is None
+
+    def test_shortest_path_chosen(self) -> None:
+        """Longer alternative path exists — shortest_path should pick the direct one."""
+        g = PropertyGraph()
+        for p in ("a.py", "b.py", "c.py", "d.py"):
+            _file(g, p)
+        g.add_edge("a.py", "b.py", "IMPORTS")
+        g.add_edge("b.py", "d.py", "IMPORTS")
+        g.add_edge("a.py", "c.py", "IMPORTS")
+        g.add_edge("c.py", "d.py", "IMPORTS")
+        q = GraphQueries(g)
+        path = q.dependency_path("a.py", "d.py")
+        assert path is not None
+        assert len(path) == 3  # a→b→d  or  a→c→d (both length 3)
+
+
+# ---------------------------------------------------------------------------
+# raises_exception
+# ---------------------------------------------------------------------------
+
+class TestRaisesException:
+    def test_finds_raiser(self) -> None:
+        g = PropertyGraph()
+        fn = _fn(g, "f.py::boom", "boom")
+        g.add_edge("f.py::boom", "ValueError", "RAISES")
+        q = GraphQueries(g)
+        result = q.raises_exception("ValueError")
+        assert len(result) == 1
+        assert result[0].name == "boom"
+
+    def test_no_match_returns_empty(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::safe", "safe")
+        q = GraphQueries(g)
+        assert q.raises_exception("KeyError") == []
+
+    def test_does_not_match_other_exceptions(self) -> None:
+        g = PropertyGraph()
+        fn = _fn(g, "f.py::foo", "foo")
+        g.add_edge("f.py::foo", "TypeError", "RAISES")
+        q = GraphQueries(g)
+        assert q.raises_exception("ValueError") == []
+
+    def test_multiple_functions_same_exception(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::a", "a")
+        _fn(g, "f.py::b", "b")
+        g.add_edge("f.py::a", "ValueError", "RAISES")
+        g.add_edge("f.py::b", "ValueError", "RAISES")
+        q = GraphQueries(g)
+        result = q.raises_exception("ValueError")
+        assert len(result) == 2
+
+    def test_sorted_by_id(self) -> None:
+        g = PropertyGraph()
+        _fn(g, "f.py::z", "z")
+        _fn(g, "f.py::a", "a")
+        g.add_edge("f.py::z", "ValueError", "RAISES")
+        g.add_edge("f.py::a", "ValueError", "RAISES")
+        q = GraphQueries(g)
+        result = q.raises_exception("ValueError")
+        ids = [fn.id for fn in result]
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# callers / callees
+# ---------------------------------------------------------------------------
+
+class TestCallersCallees:
+    def _call_graph(self) -> PropertyGraph:
+        g = PropertyGraph()
+        _fn(g, "f.py::a", "a")
+        _fn(g, "f.py::b", "b")
+        _fn(g, "f.py::c", "c")
+        g.add_edge("f.py::b", "f.py::a", "CALLS")
+        g.add_edge("f.py::c", "f.py::a", "CALLS")
+        g.add_edge("f.py::a", "f.py::c", "CALLS")
+        return g
+
+    def test_callers(self) -> None:
+        q = GraphQueries(self._call_graph())
+        result = q.callers("f.py::a")
+        names = {fn.name for fn in result}
+        assert names == {"b", "c"}
+
+    def test_callees(self) -> None:
+        q = GraphQueries(self._call_graph())
+        result = q.callees("f.py::a")
+        names = {fn.name for fn in result}
+        assert names == {"c"}
+
+    def test_callers_bare_name(self) -> None:
+        q = GraphQueries(self._call_graph())
+        result = q.callers("a")
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# file_fan_in
+# ---------------------------------------------------------------------------
+
+class TestFileFanIn:
+    def test_most_imported_first(self) -> None:
+        g = PropertyGraph()
+        core = _file(g, "core.py")
+        for i in range(3):
+            f = _file(g, f"user{i}.py")
+            g.add_edge(f"user{i}.py", "core.py", "IMPORTS")
+        q = GraphQueries(g)
+        result = q.file_fan_in(top_k=5)
+        assert result[0][0].path == "core.py"
+        assert result[0][1] == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration — build from real source and run all queries
+# ---------------------------------------------------------------------------
+
+class TestIntegration:
+    def test_full_pipeline(self, tmp_path: Path) -> None:
+        _make_source(tmp_path, "db.py", """\
+            import os
+
+            class Database:
+                def __init__(self):
+                    self._data = {}
+
+                def add(self, key, value):
+                    if key in self._data:
+                        raise KeyError(f"duplicate: {key}")
+                    self._data[key] = value
+
+                def get(self, key):
+                    return self._data.get(key)
+
+                def _internal(self):
+                    pass
+        """)
+        _make_source(tmp_path, "service.py", """\
+            from db import Database
+
+            def create(db, key, value):
+                db.add(key, value)
+
+            def fetch(db, key):
+                return db.get(key)
+
+            def helper():
+                pass
+        """)
+        _make_source(tmp_path, "cli.py", """\
+            from service import create, fetch
+
+            def run(db, key, value):
+                create(db, key, value)
+                result = fetch(db, key)
+                return result
+        """)
+
+        g = PropertyGraph()
+        g.build_from_directory(tmp_path)
+        q = GraphQueries(g)
+
+        # node/edge sanity
+        assert g.node_count(node_type="function") >= 5
+        assert g.edge_count(edge_type="CALLS") >= 2
+        assert g.edge_count(edge_type="IMPORTS") >= 2
+
+        # complexity hotspots returns something
+        hotspots = q.complexity_hotspots(top_k=5)
+        assert len(hotspots) > 0
+        assert all(isinstance(fn, FunctionNode) for fn, _ in hotspots)
+
+        # fan_in returns something
+        fi = q.fan_in(top_k=5)
+        assert len(fi) > 0
+
+        # uncalled_functions: helper() is never called
+        uncalled = q.uncalled_functions()
+        assert any(fn.name == "helper" for fn in uncalled)
+
+        # raises_exception
+        raisers = q.raises_exception("KeyError")
+        assert len(raisers) >= 1
+
+        # dependency_path: cli → service
+        # The parser emits IMPORTS edges to the module name ("service"),
+        # so dependency_path resolves "service.py" → "service" internally.
+        path = q.dependency_path("cli.py", "service.py")
+        assert path is not None
+        assert path[0] == "cli.py"
+        assert path[-1] in ("service.py", "service")


### PR DESCRIPTION
## Summary

Implements issue #7 — named structural queries that answer real engineering questions using the property graph.

## New files

| File | Purpose |
|---|---|
| `ckg/queries.py` | `GraphQueries` — 8 named queries |
| `tests/test_queries.py` | 32 unit tests + 1 end-to-end integration test |

## Queries

```python
from ckg.graph import PropertyGraph
from ckg.queries import GraphQueries

g = PropertyGraph()
g.build_from_directory("my_project/")
q = GraphQueries(g)

# What breaks if I change this function?
q.impact_radius("database.py::add_episode", depth=3)
# → {1: [direct_callers], 2: [callers_of_callers], ...}

# Most-called functions
q.fan_in(top_k=10)
# → [(FunctionNode, caller_count), ...]

# Dead code candidates
q.uncalled_functions()
# → [FunctionNode, ...]  (excludes dunders, main, test_*)

# Complexity hotspots
q.complexity_hotspots(top_k=10)
# → [(FunctionNode, complexity), ...]

# How does cli.py depend on database.py?
q.dependency_path("cli.py", "database.py")
# → ["cli.py", "service.py", "database.py"]

# All functions that raise ValueError
q.raises_exception("ValueError")
# → [FunctionNode, ...]

# Callers / callees by name or full ID
q.callers("add_episode")
q.callees("add_episode")

# Most-imported files
q.file_fan_in(top_k=10)
```

## Implementation notes

- **`impact_radius`**: BFS over CALLS predecessors; bare function name resolution; diamond-path deduplication
- **`dependency_path`**: builds a lightweight `nx.DiGraph` from IMPORTS edges only, then `nx.shortest_path`; resolves `service.py` → `service` by preferring the module-name form (higher in-degree heuristic)
- **`uncalled_functions`**: excludes all dunder methods, `main`, `setup`/`teardown`, and `test_*` prefixes

## Tests

32 new tests + 60 existing = **92 total, all passing**

## Next

Issue #1 (CLI — wire queries to `ckg query` commands) and #2 (DuckDB persistence) are both now fully unblocked.