### PR TITLE
feat: DuckDB persistence — save, load, and incremental rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uv run ckg --help
 | #5 | Project setup | ✅ Done |
 | #6 | AST parser | ✅ Done |
 | #4 | Property graph | ✅ Done |
-| #2 | DuckDB persistence | 🔜 Planned |
+| #2 | DuckDB persistence | ✅ Done |
 | #7 | Structural queries | ✅ Done |
 | #1 | CLI (full) | ✅ Done |
 | #3 | Eval on P³ | ✅ Done |

--- a/ckg/cli.py
+++ b/ckg/cli.py
@@ -15,8 +15,13 @@ from rich import box
 from ckg.graph import PropertyGraph
 from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
 from ckg.queries import GraphQueries
+from ckg.store import GraphStore
 
 console = Console()
+
+# Default DB location (can be overridden with --db)
+_DEFAULT_DB = Path.home() / ".ckg" / "graph.db"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,16 +40,11 @@ def _complexity_text(cc: int) -> Text:
     return Text(str(cc), style=style)
 
 
-def _build_graph(repo: str) -> PropertyGraph:
-    """Parse *repo* and return a populated PropertyGraph, with progress output."""
-    root = Path(repo).resolve()
-    console.print(f"[dim]Scanning[/dim] [cyan]{root}[/cyan]…")
-    g = PropertyGraph()
-    g.build_from_directory(root)
+def _print_graph_summary(g: PropertyGraph, *, prefix: str = "✓") -> None:
     by_type = g.node_count_by_type()
     by_edge = g.edge_count_by_type()
     console.print(
-        f"[green]✓[/green] Built graph: "
+        f"[green]{prefix}[/green] Graph: "
         f"[bold]{g.node_count()}[/bold] nodes "
         f"([cyan]{by_type.get('function', 0)}[/cyan] functions, "
         f"[cyan]{by_type.get('class', 0)}[/cyan] classes, "
@@ -53,6 +53,50 @@ def _build_graph(repo: str) -> PropertyGraph:
         f"([cyan]{by_edge.get('CALLS', 0)}[/cyan] calls, "
         f"[cyan]{by_edge.get('IMPORTS', 0)}[/cyan] imports)"
     )
+
+
+def _load_or_build_graph(repo: str, db_path: Path, *, force: bool = False) -> PropertyGraph:
+    """Return a graph, loading from the DB cache when available and fresh.
+
+    If *force* is True, always re-parse from source.
+    Falls back to a full parse when no DB exists yet.
+    """
+    store = GraphStore(db_path)
+    root = Path(repo).resolve()
+
+    if not force and db_path.exists():
+        # Check whether the cache is stale (any file needs re-parse)
+        stale = any(
+            store.needs_reparse(f, root)
+            for f in store.stored_files()
+        )
+        # Also check for new files not yet in cache
+        _SKIP = {".venv", "__pycache__", ".git", "dist", "build",
+                 ".mypy_cache", ".ruff_cache"}
+        known = set(store.stored_files())
+        new_files = [
+            str(p.relative_to(root))
+            for p in sorted(root.rglob("*.py"))
+            if not any(part in _SKIP or part.endswith(".egg-info") for part in p.parts)
+            and str(p.relative_to(root)) not in known
+        ]
+
+        if not stale and not new_files:
+            console.print(f"[dim]Loading graph from cache[/dim] [cyan]{db_path}[/cyan]…")
+            g = store.load()
+            _print_graph_summary(g, prefix="✓ Loaded")
+            return g
+
+        console.print(f"[dim]Cache stale — rebuilding[/dim] [cyan]{root}[/cyan]…")
+        g, reparsed = store.rebuild_incremental(root)
+        console.print(f"[green]✓[/green] Re-parsed [bold]{len(reparsed)}[/bold] file(s)")
+        _print_graph_summary(g)
+        return g
+
+    # No cache — full parse
+    console.print(f"[dim]Scanning[/dim] [cyan]{root}[/cyan]…")
+    g = store.build_and_save(root)
+    _print_graph_summary(g, prefix="✓ Built")
     return g
 
 
@@ -69,13 +113,26 @@ def _require_arg(args: tuple[str, ...], n: int, usage: str) -> list[str]:
 
 @click.group()
 @click.version_option(package_name="code-knowledge-graph")
-def cli() -> None:
+@click.option(
+    "--db",
+    default=str(_DEFAULT_DB),
+    show_default=True,
+    envvar="CKG_DB",
+    help="Path to the DuckDB graph cache.",
+)
+@click.pass_context
+def cli(ctx: click.Context, db: str) -> None:
     """Code Knowledge Graph — structural analysis for Python codebases.
 
     Build a property graph from your Python source code and answer
     structural questions: impact radius, dead code, complexity hotspots,
     dependency paths, and more.
+
+    The graph is cached in a DuckDB file (default: ~/.ckg/graph.db).
+    Subsequent queries load from cache and only re-parse changed files.
     """
+    ctx.ensure_object(dict)
+    ctx.obj["db_path"] = Path(db)
 
 
 # ---------------------------------------------------------------------------
@@ -84,15 +141,50 @@ def cli() -> None:
 
 @cli.command()
 @click.argument("repo", default=".", type=click.Path(exists=True))
-@click.option("--incremental", is_flag=True, help="Only re-parse changed files (not yet implemented).")
-def build(repo: str, incremental: bool) -> None:
-    """Build the knowledge graph from a Python repository.
+@click.option("--incremental", is_flag=True,
+              help="Only re-parse files changed since last build.")
+@click.option("--force", is_flag=True,
+              help="Force full rebuild, ignoring the cache.")
+@click.pass_context
+def build(ctx: click.Context, repo: str, incremental: bool, force: bool) -> None:
+    """Build (or update) the knowledge graph from a Python repository.
 
     REPO is the path to the root of the repository (default: current directory).
+    The graph is persisted to the DuckDB cache for fast subsequent queries.
     """
-    if incremental:
-        console.print("[yellow]--incremental is not yet implemented; running full build.[/yellow]")
-    _build_graph(repo)
+    db_path: Path = ctx.obj["db_path"]
+    root = Path(repo).resolve()
+    store = GraphStore(db_path)
+
+    if force:
+        console.print(f"[dim]Force rebuild from[/dim] [cyan]{root}[/cyan]…")
+        g = store.build_and_save(root)
+        _print_graph_summary(g, prefix="✓ Built")
+    elif incremental and db_path.exists():
+        console.print(f"[dim]Incremental rebuild of[/dim] [cyan]{root}[/cyan]…")
+        g, reparsed = store.rebuild_incremental(root)
+        if reparsed:
+            console.print(
+                f"[green]✓[/green] Re-parsed [bold]{len(reparsed)}[/bold] file(s): "
+                + ", ".join(reparsed[:5])
+                + (" …" if len(reparsed) > 5 else "")
+            )
+        else:
+            console.print("[green]✓[/green] Nothing changed — cache is up to date.")
+        _print_graph_summary(g)
+    else:
+        if incremental:
+            console.print("[yellow]No cache found — running full build.[/yellow]")
+        console.print(f"[dim]Scanning[/dim] [cyan]{root}[/cyan]…")
+        g = store.build_and_save(root)
+        _print_graph_summary(g, prefix="✓ Built")
+
+    stats = store.db_stats()
+    console.print(
+        f"[dim]Cache:[/dim] [cyan]{db_path}[/cyan] "
+        f"({stats['nodes']} nodes, {stats['edges']} edges, "
+        f"{stats['tracked_files']} tracked files)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +203,8 @@ def build(repo: str, incremental: bool) -> None:
               help="BFS depth for impact query.")
 @click.option("--top", default=10, show_default=True,
               help="Number of results for hotspots / fan-in queries.")
-def query(subcommand: str, args: tuple[str, ...], repo: str, depth: int, top: int) -> None:
+@click.pass_context
+def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str, depth: int, top: int) -> None:
     """Run a structural query against the knowledge graph.
 
     \b
@@ -124,7 +217,8 @@ def query(subcommand: str, args: tuple[str, ...], repo: str, depth: int, top: in
       path    <file_a> <file_b>   Dependency path between two files
       raises  <ExceptionName>     Functions that raise an exception
     """
-    g = _build_graph(repo)
+    db_path: Path = ctx.obj["db_path"]
+    g = _load_or_build_graph(repo, db_path)
     q = GraphQueries(g)
 
     sub = subcommand.lower()
@@ -262,7 +356,8 @@ def query(subcommand: str, args: tuple[str, ...], repo: str, depth: int, top: in
 @click.argument("target")
 @click.option("--repo", default=".", type=click.Path(exists=True),
               help="Repository root (default: current directory).")
-def inspect(kind: str, target: str, repo: str) -> None:
+@click.pass_context
+def inspect(ctx: click.Context, kind: str, target: str, repo: str) -> None:
     """Inspect a node or file in the knowledge graph.
 
     \b
@@ -270,7 +365,8 @@ def inspect(kind: str, target: str, repo: str) -> None:
       node <node_id>   Full details for a single function or class node
       file <path>      All nodes defined in a file
     """
-    g = _build_graph(repo)
+    db_path: Path = ctx.obj["db_path"]
+    g = _load_or_build_graph(repo, db_path)
     q = GraphQueries(g)
 
     if kind == "node":
@@ -451,9 +547,11 @@ def _inspect_file_node(fnode: FileNode, g: PropertyGraph) -> None:
 @cli.command()
 @click.option("--repo", default=".", type=click.Path(exists=True),
               help="Repository root (default: current directory).")
-def stats(repo: str) -> None:
+@click.pass_context
+def stats(ctx: click.Context, repo: str) -> None:
     """Show summary statistics for the knowledge graph."""
-    g = _build_graph(repo)
+    db_path: Path = ctx.obj["db_path"]
+    g = _load_or_build_graph(repo, db_path)
     q = GraphQueries(g)
 
     by_type = g.node_count_by_type()

--- a/ckg/store.py
+++ b/ckg/store.py
@@ -1,0 +1,509 @@
+"""DuckDB persistence layer for the Code Knowledge Graph.
+
+Serialises a :class:`~ckg.graph.PropertyGraph` into two DuckDB tables
+(``nodes`` and ``edges``) plus a ``file_mtimes`` table that drives
+incremental rebuilds.
+
+Usage
+-----
+    from ckg.store import GraphStore
+
+    store = GraphStore()               # default: ~/.ckg/graph.db
+    store.build_and_save("my_repo/")   # parse + persist
+
+    # Later session — instant load, no re-parsing
+    graph = store.load()
+
+    # After editing a file — only re-parse what changed
+    store.rebuild_incremental("my_repo/")
+    graph = store.load()
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import duckdb
+
+from ckg.models import (
+    ClassNode,
+    FileNode,
+    FunctionNode,
+    ModuleNode,
+    Node,
+)
+
+if TYPE_CHECKING:
+    from ckg.graph import PropertyGraph
+
+
+# ---------------------------------------------------------------------------
+# SQL schema
+# ---------------------------------------------------------------------------
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS nodes (
+    id          TEXT PRIMARY KEY,
+    node_type   TEXT    NOT NULL,
+    name        TEXT,
+    file_path   TEXT,
+    line_start  INTEGER,
+    properties  JSON    NOT NULL DEFAULT '{}',
+    parsed_at   TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id          INTEGER PRIMARY KEY,
+    src_id      TEXT    NOT NULL,
+    dst_id      TEXT    NOT NULL,
+    edge_type   TEXT    NOT NULL,
+    weight      INTEGER NOT NULL DEFAULT 1,
+    line        INTEGER,
+    properties  JSON    NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS file_mtimes (
+    path        TEXT PRIMARY KEY,
+    mtime       DOUBLE  NOT NULL,
+    parsed_at   TIMESTAMP NOT NULL
+);
+"""
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+def _node_to_row(node: Node, now: datetime) -> tuple:
+    """Convert a typed node dataclass to a ``(id, node_type, name, file_path,
+    line_start, properties_json, parsed_at)`` tuple."""
+    d = asdict(node)
+    nid       = d.pop("id")
+    node_type = d.pop("node_type")
+    name      = d.pop("name", None)
+    file_path = d.pop("file_path", None)
+    line_start = d.pop("line_start", None)
+    # everything else goes into the JSON blob
+    props = json.dumps(d)
+    return (nid, node_type, name, file_path, line_start, props, now)
+
+
+def _row_to_node(row: tuple) -> Node:
+    """Reconstruct a typed node from a DB row."""
+    nid, node_type, name, file_path, line_start, props_json, _ = row
+    props: dict = json.loads(props_json) if props_json else {}
+
+    if node_type == "file":
+        return FileNode(
+            id=nid,
+            path=props.get("path", nid),
+            line_count=props.get("line_count", 0),
+            avg_complexity=props.get("avg_complexity", 0.0),
+        )
+    if node_type == "function":
+        return FunctionNode(
+            id=nid,
+            name=name or "",
+            file_path=file_path or "",
+            line_start=line_start or 0,
+            line_end=props.get("line_end", line_start or 0),
+            signature=props.get("signature", ""),
+            docstring=props.get("docstring"),
+            return_type=props.get("return_type"),
+            cyclomatic_complexity=props.get("cyclomatic_complexity", 1),
+            is_async=props.get("is_async", False),
+            is_method=props.get("is_method", False),
+            class_name=props.get("class_name"),
+            param_count=props.get("param_count", 0),
+        )
+    if node_type == "class":
+        return ClassNode(
+            id=nid,
+            name=name or "",
+            file_path=file_path or "",
+            line_start=line_start or 0,
+            line_end=props.get("line_end", line_start or 0),
+            bases=props.get("bases", []),
+            docstring=props.get("docstring"),
+            method_count=props.get("method_count", 0),
+        )
+    if node_type == "module":
+        return ModuleNode(
+            id=nid,
+            name=name or nid,
+            is_stdlib=props.get("is_stdlib", False),
+            is_local=props.get("is_local", False),
+        )
+    raise ValueError(f"Unknown node_type {node_type!r} for id={nid!r}")
+
+
+# ---------------------------------------------------------------------------
+# GraphStore
+# ---------------------------------------------------------------------------
+
+class GraphStore:
+    """Persist and load a :class:`~ckg.graph.PropertyGraph` via DuckDB.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the DuckDB file.  Defaults to ``~/.ckg/graph.db``.
+        The parent directory is created automatically.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        if db_path is None:
+            db_path = Path.home() / ".ckg" / "graph.db"
+        self._db_path = Path(db_path).expanduser().resolve()
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Internal connection management
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> duckdb.DuckDBPyConnection:
+        conn = duckdb.connect(str(self._db_path))
+        # DuckDB doesn't have executescript — run each statement individually
+        for stmt in _DDL.strip().split(";"):
+            stmt = stmt.strip()
+            if stmt:
+                conn.execute(stmt)
+        return conn
+
+    # ------------------------------------------------------------------
+    # Save
+    # ------------------------------------------------------------------
+
+    def save(self, graph: "PropertyGraph", project_root: str | Path | None = None) -> None:
+        """Serialise *graph* to DuckDB, replacing any previous data.
+
+        Parameters
+        ----------
+        graph:
+            The populated :class:`~ckg.graph.PropertyGraph` to persist.
+        project_root:
+            When provided, mtime records are written for every
+            ``FileNode`` whose path can be resolved under *project_root*.
+        """
+        now = datetime.now(timezone.utc)
+        conn = self._connect()
+
+        try:
+            conn.execute("BEGIN")
+
+            # Wipe existing data
+            conn.execute("DELETE FROM edges")
+            conn.execute("DELETE FROM nodes")
+            conn.execute("DELETE FROM file_mtimes")
+
+            # Insert nodes
+            node_rows = [_node_to_row(n, now) for n in graph._nodes.values()]
+            if node_rows:
+                conn.executemany(
+                    "INSERT OR REPLACE INTO nodes VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    node_rows,
+                )
+
+            # Insert edges
+            edge_rows = []
+            for i, (src, dst, data) in enumerate(graph.nx_graph.edges(data=True)):
+                edge_rows.append((
+                    i,
+                    src,
+                    dst,
+                    data.get("edge_type", "UNKNOWN"),
+                    data.get("weight", 1),
+                    data.get("line"),
+                    json.dumps({
+                        k: v for k, v in data.items()
+                        if k not in ("edge_type", "weight", "line")
+                    }),
+                ))
+            if edge_rows:
+                conn.executemany(
+                    "INSERT INTO edges VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    edge_rows,
+                )
+
+            # Write file mtimes
+            if project_root is not None:
+                root = Path(project_root).resolve()
+                mtime_rows = []
+                for node in graph._nodes.values():
+                    if not isinstance(node, FileNode):
+                        continue
+                    abs_path = root / node.path
+                    if abs_path.exists():
+                        mtime_rows.append((node.path, abs_path.stat().st_mtime, now))
+                if mtime_rows:
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO file_mtimes VALUES (?, ?, ?)",
+                        mtime_rows,
+                    )
+
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Load
+    # ------------------------------------------------------------------
+
+    def load(self) -> "PropertyGraph":
+        """Reconstruct a :class:`~ckg.graph.PropertyGraph` from DuckDB.
+
+        Returns an empty graph if the database contains no data.
+        """
+        from ckg.graph import PropertyGraph
+
+        conn = self._connect()
+        try:
+            graph = PropertyGraph()
+
+            # Restore nodes
+            rows = conn.execute(
+                "SELECT id, node_type, name, file_path, line_start, properties, parsed_at "
+                "FROM nodes"
+            ).fetchall()
+            for row in rows:
+                node = _row_to_node(row)
+                graph.add_node(node)
+
+            # Restore edges
+            edge_rows = conn.execute(
+                "SELECT src_id, dst_id, edge_type, weight, line FROM edges"
+            ).fetchall()
+            for src, dst, edge_type, weight, line in edge_rows:
+                graph.add_edge(src, dst, edge_type, weight=weight, line=line)  # type: ignore[arg-type]
+
+            return graph
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Mtime helpers
+    # ------------------------------------------------------------------
+
+    def needs_reparse(self, file_path: str, project_root: str | Path) -> bool:
+        """Return ``True`` if *file_path* is new or has been modified since
+        the last ``save()`` call.
+
+        Parameters
+        ----------
+        file_path:
+            Relative path as stored in the graph (e.g. ``database.py``).
+        project_root:
+            Absolute path to the repository root.
+        """
+        abs_path = Path(project_root).resolve() / file_path
+        if not abs_path.exists():
+            return False  # file deleted — handled by invalidate_file
+
+        current_mtime = abs_path.stat().st_mtime
+
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT mtime FROM file_mtimes WHERE path = ?", (file_path,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return True  # never seen before
+        return current_mtime > row[0]
+
+    def stored_files(self) -> list[str]:
+        """Return all file paths currently tracked in the mtime table."""
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT path FROM file_mtimes").fetchall()
+            return [r[0] for r in rows]
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Invalidation
+    # ------------------------------------------------------------------
+
+    def invalidate_file(self, file_path: str) -> None:
+        """Remove all nodes and edges that originated from *file_path*,
+        and delete its mtime record so it is re-parsed next time.
+
+        Node IDs that start with ``file_path + "::"`` are removed, along
+        with the ``FileNode`` whose id equals *file_path*.
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            prefix = file_path + "::"
+
+            # Nodes: file node itself + all function/class nodes in the file
+            conn.execute(
+                "DELETE FROM nodes WHERE id = ? OR id LIKE ?",
+                (file_path, prefix + "%"),
+            )
+            # Edges: any edge whose src or dst originated in this file
+            conn.execute(
+                "DELETE FROM edges WHERE src_id = ? OR src_id LIKE ? "
+                "OR dst_id = ? OR dst_id LIKE ?",
+                (file_path, prefix + "%", file_path, prefix + "%"),
+            )
+            # Mtime record
+            conn.execute("DELETE FROM file_mtimes WHERE path = ?", (file_path,))
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Incremental rebuild
+    # ------------------------------------------------------------------
+
+    def rebuild_incremental(
+        self,
+        root: str | Path,
+        *,
+        verbose: bool = False,
+    ) -> tuple["PropertyGraph", list[str]]:
+        """Re-parse only files that have changed since the last save.
+
+        Algorithm
+        ---------
+        1. Load the existing graph from DuckDB.
+        2. Walk all ``.py`` files under *root*.
+        3. For each file that ``needs_reparse()`` returns ``True``:
+           a. Invalidate its nodes/edges in the DB.
+           b. Parse the file and ingest the result into *graph*.
+        4. Persist the updated graph and return it together with the
+           list of re-parsed relative paths.
+
+        Parameters
+        ----------
+        root:
+            Repository root to scan.
+        verbose:
+            If ``True`` print each re-parsed file to stdout.
+
+        Returns
+        -------
+        (graph, reparsed_paths)
+            The updated :class:`~ckg.graph.PropertyGraph` and the list
+            of relative file paths that were re-parsed.
+        """
+        from ckg.parsers.python import parse_directory, parse_file
+
+        root = Path(root).resolve()
+        _SKIP_DIRS = {".venv", "__pycache__", ".git", "dist", "build",
+                      ".mypy_cache", ".ruff_cache"}
+
+        # 1. Load current state
+        graph = self.load()
+
+        reparsed: list[str] = []
+
+        # 2. Walk .py files
+        for py_file in sorted(root.rglob("*.py")):
+            if any(part in _SKIP_DIRS or part.endswith(".egg-info")
+                   for part in py_file.parts):
+                continue
+            rel = str(py_file.relative_to(root))
+
+            # 3. Check mtime
+            if not self.needs_reparse(rel, root):
+                continue
+
+            if verbose:
+                print(f"  re-parsing {rel}")
+
+            # 3a. Remove stale data from in-memory graph too
+            _invalidate_in_graph(graph, rel)
+
+            # 3b. Parse and ingest
+            try:
+                from ckg.parsers.python import parse_file as _pf
+                result = _pf(py_file, root)
+                graph._ingest_parse_result(result)
+                reparsed.append(rel)
+            except SyntaxError:
+                if verbose:
+                    print(f"    syntax error — skipped")
+
+        # 4. Persist updated graph
+        self.save(graph, project_root=root)
+
+        return graph, reparsed
+
+    # ------------------------------------------------------------------
+    # Convenience: build + save in one call
+    # ------------------------------------------------------------------
+
+    def build_and_save(self, root: str | Path) -> "PropertyGraph":
+        """Full build: parse *root*, save to DB, return the graph."""
+        from ckg.graph import PropertyGraph
+
+        graph = PropertyGraph()
+        graph.build_from_directory(root)
+        self.save(graph, project_root=root)
+        return graph
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def db_stats(self) -> dict[str, int]:
+        """Return ``{nodes, edges, tracked_files}`` counts from the DB."""
+        conn = self._connect()
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+            e = conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+            f = conn.execute("SELECT COUNT(*) FROM file_mtimes").fetchone()[0]
+            return {"nodes": n, "edges": e, "tracked_files": f}
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Repr
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"GraphStore({self._db_path})"
+
+
+# ---------------------------------------------------------------------------
+# Internal helper — remove a file's contribution from an in-memory graph
+# ---------------------------------------------------------------------------
+
+def _invalidate_in_graph(graph: "PropertyGraph", file_path: str) -> None:
+    """Remove all nodes and edges originating from *file_path* from the
+    in-memory *graph* (mirrors :meth:`GraphStore.invalidate_file` for DB)."""
+    prefix = file_path + "::"
+
+    to_remove = [
+        nid for nid in graph._nodes
+        if nid == file_path or nid.startswith(prefix)
+    ]
+    for nid in to_remove:
+        del graph._nodes[nid]
+        if nid in graph._graph:
+            graph._graph.remove_node(nid)
+
+    # Also remove edges where src or dst matches
+    edges_to_remove = [
+        (src, dst, key)
+        for src, dst, key, data in graph._graph.edges(data=True, keys=True)
+        if (src == file_path or src.startswith(prefix)
+            or dst == file_path or dst.startswith(prefix))
+    ]
+    for src, dst, key in edges_to_remove:
+        if graph._graph.has_edge(src, dst, key):
+            graph._graph.remove_edge(src, dst, key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,407 @@
+"""Tests for ckg.store.GraphStore."""
+
+from __future__ import annotations
+
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
+from ckg.store import GraphStore, _invalidate_in_graph
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Three-file repo used across most tests."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "db.py").write_text(textwrap.dedent("""\
+        import os
+
+        class Database:
+            def __init__(self):
+                self._data = {}
+
+            def add(self, key, value):
+                if key in self._data:
+                    raise KeyError("dup")
+                self._data[key] = value
+
+            def get(self, key):
+                return self._data.get(key)
+    """))
+    (tmp_path / "service.py").write_text(textwrap.dedent("""\
+        from db import Database
+
+        def create(db, key, value):
+            db.add(key, value)
+
+        def fetch(db, key):
+            return db.get(key)
+
+        def helper():
+            pass
+    """))
+    (tmp_path / "cli.py").write_text(textwrap.dedent("""\
+        from service import create, fetch
+
+        def run(db, key, value):
+            create(db, key, value)
+            return fetch(db, key)
+    """))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# GraphStore initialisation
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_creates_parent_dir(self, tmp_path: Path) -> None:
+        db = tmp_path / "subdir" / "graph.db"
+        store = GraphStore(db)
+        assert db.parent.exists()
+
+    def test_default_path_is_home_ckg(self) -> None:
+        store = GraphStore()
+        assert str(store._db_path).endswith("graph.db")
+        assert ".ckg" in str(store._db_path)
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        store = GraphStore(str(tmp_path / "g.db"))
+        assert store._db_path.suffix == ".db"
+
+
+# ---------------------------------------------------------------------------
+# Save and load round-trip
+# ---------------------------------------------------------------------------
+
+class TestSaveLoad:
+    def test_node_count_survives_round_trip(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+
+        g1 = store.build_and_save(repo)
+        g2 = store.load()
+
+        assert g2.node_count() == g1.node_count()
+
+    def test_edge_count_survives_round_trip(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+
+        g1 = store.build_and_save(repo)
+        g2 = store.load()
+
+        assert g2.edge_count() == g1.edge_count()
+
+    def test_function_node_fields_survive(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        g = store.load()
+        node = g.get_node("service.py::create")
+        assert isinstance(node, FunctionNode)
+        assert node.name == "create"
+        assert node.file_path == "service.py"
+        assert node.line_start > 0
+
+    def test_file_node_fields_survive(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        g = store.load()
+        node = g.get_node("db.py")
+        assert isinstance(node, FileNode)
+        assert node.path == "db.py"
+        assert node.line_count > 0
+
+    def test_class_node_fields_survive(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        g = store.load()
+        node = g.get_node("db.py::Database")
+        assert isinstance(node, ClassNode)
+        assert node.name == "Database"
+        assert node.method_count >= 3
+
+    def test_module_node_fields_survive(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        g = store.load()
+        node = g.get_node("os")
+        assert isinstance(node, ModuleNode)
+        assert node.is_stdlib is True
+
+    def test_edge_types_survive(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        g1 = store.build_and_save(repo)
+        g2 = store.load()
+
+        assert g2.edge_count_by_type().get("CALLS", 0) > 0
+        assert g2.edge_count_by_type().get("IMPORTS", 0) > 0
+        assert g2.edge_count_by_type().get("DEFINES", 0) > 0
+
+    def test_traversal_works_after_load(self, tmp_path: Path) -> None:
+        from ckg.queries import GraphQueries
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        g = store.load()
+        fn = g.get_node("service.py::create")
+        assert fn is not None
+        # Use GraphQueries.callers() which handles bare-name CALLS edges
+        # (cli.py::run calls create(...) → dst_id="create", not full ID)
+        q = GraphQueries(g)
+        callers = q.callers("service.py::create")
+        assert any(n.id == "cli.py::run" for n in callers)
+
+    def test_empty_db_load_returns_empty_graph(self, tmp_path: Path) -> None:
+        store = GraphStore(tmp_path / "empty.db")
+        g = store.load()
+        assert g.node_count() == 0
+        assert g.edge_count() == 0
+
+    def test_save_overwrites_previous(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+        count1 = store.db_stats()["nodes"]
+
+        # Second save with the same data should give same count
+        store.build_and_save(repo)
+        count2 = store.db_stats()["nodes"]
+        assert count1 == count2
+
+
+# ---------------------------------------------------------------------------
+# Mtime tracking
+# ---------------------------------------------------------------------------
+
+class TestMtime:
+    def test_needs_reparse_true_for_new_file(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        new_file = repo / "new.py"
+        new_file.write_text("def fresh(): pass\n")
+        assert store.needs_reparse("new.py", repo) is True
+
+    def test_needs_reparse_false_for_unchanged_file(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+        assert store.needs_reparse("db.py", repo) is False
+
+    def test_needs_reparse_true_after_modification(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        # Modify the file slightly in the future so mtime definitely changes
+        target = repo / "service.py"
+        time.sleep(0.05)
+        target.write_text(target.read_text() + "\n# modified\n")
+        assert store.needs_reparse("service.py", repo) is True
+
+    def test_stored_files_lists_tracked_paths(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        tracked = store.stored_files()
+        assert "db.py" in tracked
+        assert "service.py" in tracked
+        assert "cli.py" in tracked
+
+
+# ---------------------------------------------------------------------------
+# Invalidation
+# ---------------------------------------------------------------------------
+
+class TestInvalidation:
+    def test_invalidate_removes_file_node(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        store.invalidate_file("service.py")
+        g = store.load()
+        assert g.get_node("service.py") is None
+
+    def test_invalidate_removes_function_nodes(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        store.invalidate_file("service.py")
+        g = store.load()
+        assert g.get_node("service.py::create") is None
+        assert g.get_node("service.py::fetch") is None
+
+    def test_invalidate_removes_mtime_record(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        store.invalidate_file("service.py")
+        assert "service.py" not in store.stored_files()
+
+    def test_invalidate_does_not_remove_other_files(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        store.invalidate_file("service.py")
+        g = store.load()
+        assert g.get_node("db.py") is not None
+        assert g.get_node("db.py::Database") is not None
+
+
+# ---------------------------------------------------------------------------
+# Incremental rebuild
+# ---------------------------------------------------------------------------
+
+class TestIncrementalRebuild:
+    def test_unchanged_repo_reparses_nothing(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        _, reparsed = store.rebuild_incremental(repo)
+        assert reparsed == []
+
+    def test_modified_file_is_reparsed(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        time.sleep(0.05)
+        (repo / "service.py").write_text(
+            (repo / "service.py").read_text() + "\ndef new_fn(): pass\n"
+        )
+
+        _, reparsed = store.rebuild_incremental(repo)
+        assert "service.py" in reparsed
+        assert "db.py" not in reparsed
+
+    def test_incremental_preserves_unmodified_nodes(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        time.sleep(0.05)
+        (repo / "service.py").write_text(
+            (repo / "service.py").read_text() + "\ndef added(): pass\n"
+        )
+
+        g, _ = store.rebuild_incremental(repo)
+        # db.py untouched — its nodes must still be present
+        assert g.get_node("db.py::Database") is not None
+        # New function added to service.py
+        assert g.get_node("service.py::added") is not None
+
+    def test_new_file_is_parsed(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        time.sleep(0.05)
+        (repo / "extra.py").write_text("def extra_fn(): pass\n")
+
+        g, reparsed = store.rebuild_incremental(repo)
+        assert "extra.py" in reparsed
+        assert g.get_node("extra.py::extra_fn") is not None
+
+    def test_node_edge_counts_consistent_after_incremental(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        g_full = store.build_and_save(repo)
+
+        time.sleep(0.05)
+        (repo / "cli.py").write_text(
+            (repo / "cli.py").read_text() + "\ndef extra(): pass\n"
+        )
+
+        g_inc, _ = store.rebuild_incremental(repo)
+        # Incremental graph should have at least as many nodes as full build
+        # (one extra function added)
+        assert g_inc.node_count() >= g_full.node_count()
+
+
+# ---------------------------------------------------------------------------
+# db_stats
+# ---------------------------------------------------------------------------
+
+class TestDbStats:
+    def test_stats_after_build(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+
+        stats = store.db_stats()
+        assert stats["nodes"] > 0
+        assert stats["edges"] > 0
+        assert stats["tracked_files"] == 3  # db.py, service.py, cli.py
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_in_graph helper
+# ---------------------------------------------------------------------------
+
+class TestInvalidateInGraph:
+    def test_removes_nodes_with_prefix(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        g = PropertyGraph()
+        g.build_from_directory(repo)
+
+        assert g.get_node("service.py") is not None
+        _invalidate_in_graph(g, "service.py")
+        assert g.get_node("service.py") is None
+        assert g.get_node("service.py::create") is None
+
+    def test_leaves_other_nodes_intact(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        g = PropertyGraph()
+        g.build_from_directory(repo)
+
+        _invalidate_in_graph(g, "service.py")
+        assert g.get_node("db.py") is not None
+        assert g.get_node("db.py::Database") is not None


### PR DESCRIPTION
## Summary

Implements issue #2 — graph survives across sessions and only re-parses files that have actually changed.

## New file: `ckg/store.py` — `GraphStore`

```python
from ckg.store import GraphStore

# First run — full parse + persist
store = GraphStore()                    # default: ~/.ckg/graph.db
graph = store.build_and_save("my_repo/")

# Later session — instant load (no re-parsing)
graph = store.load()

# After editing one file — only that file re-parsed
graph, reparsed = store.rebuild_incremental("my_repo/")
# reparsed = ['database.py']
```

### Schema

| Table | Key columns |
|---|---|
| `nodes` | `id`, `node_type`, `name`, `file_path`, `line_start`, `properties JSON` |
| `edges` | `src_id`, `dst_id`, `edge_type`, `weight`, `line` |
| `file_mtimes` | `path`, `mtime DOUBLE`, `parsed_at` |

## CLI changes

- Added `--db` option to root group (default `~/.ckg/graph.db`, overrideable with ``)
- `ckg build` now persists; supports `--incremental` (only re-parse changed files) and `--force` (full rebuild ignoring cache)
- `ckg query` / `ckg inspect` / `ckg stats` all load from cache on warm start, automatically rebuild stale files

## Verified against P³

```
=== First build (cold) ===
✓ Built 171 nodes, 952 edges — Cache: 13 tracked files

=== Second query (cache hit) ===
Loading graph from cache ~/.ckg/graph.db…
✓ Loaded 171 nodes, 952 edges   ← instant, no re-parsing

=== Incremental (nothing changed) ===
✓ Nothing changed — cache is up to date.
```

## Tests

29 new store tests + 130 existing = **159 total, all passing**

All issues now closed. 🎉