### PR TITLE
feat: hybrid search — semantic embeddings over function/class nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ uv run ckg --help
 | #6 | AST parser | ✅ Done |
 | #4 | Property graph | ✅ Done |
 | #2 | DuckDB persistence | ✅ Done |
+| #15 | Hybrid search (semantic embeddings) | ✅ Done |
 | #7 | Structural queries | ✅ Done |
 | #1 | CLI (full) | ✅ Done |
 | #3 | Eval on P³ | ✅ Done |

--- a/ckg/cli.py
+++ b/ckg/cli.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from rich.text import Text
 from rich import box
 
+from ckg.embedder import NodeEmbedder
 from ckg.graph import PropertyGraph
 from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
 from ckg.queries import GraphQueries
@@ -193,7 +194,7 @@ def build(ctx: click.Context, repo: str, incremental: bool, force: bool) -> None
 
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("subcommand", type=click.Choice(
-    ["impact", "callers", "callees", "hotspots", "dead-code", "path", "raises"],
+    ["impact", "callers", "callees", "hotspots", "dead-code", "path", "raises", "search"],
     case_sensitive=False,
 ))
 @click.argument("args", nargs=-1)
@@ -216,6 +217,7 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
       dead-code                   Functions never called anywhere
       path    <file_a> <file_b>   Dependency path between two files
       raises  <ExceptionName>     Functions that raise an exception
+      search  <query text>        Semantic similarity search over nodes
     """
     db_path: Path = ctx.obj["db_path"]
     g = _load_or_build_graph(repo, db_path)
@@ -344,6 +346,37 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
         t.add_column("Line", justify="right", width=6)
         for fn in raisers:
             t.add_row(fn.id, fn.file_path, str(fn.line_start))
+        console.print(t)
+
+    # ---- search -----------------------------------------------------------
+    elif sub == "search":
+        if not args:
+            console.print("[red]Error:[/red] Usage: ckg query search <query text>")
+            sys.exit(1)
+        query_text = " ".join(args)
+        embedder = NodeEmbedder(GraphStore(db_path))
+        if embedder.embed_count() == 0:
+            console.print(
+                "[yellow]No embeddings found.[/yellow] "
+                "Run [cyan]ckg embed --repo .[/cyan] first."
+            )
+            sys.exit(1)
+        results = embedder.search(query_text, graph=g, top_k=top)
+        if not results:
+            console.print(f"[yellow]No results for[/yellow] [cyan]{query_text}[/cyan]")
+            return
+        t = Table(title=f'Semantic search: "{query_text}"', box=box.SIMPLE_HEAD)
+        t.add_column("Score", justify="right", width=7, style="bold")
+        t.add_column("Node", style="cyan")
+        t.add_column("File", style="dim")
+        t.add_column("Type", style="dim", width=10)
+        for node, score in results:
+            t.add_row(
+                f"{score:.3f}",
+                node.id,
+                getattr(node, "file_path", ""),
+                node.node_type,
+            )
         console.print(t)
 
 
@@ -538,6 +571,53 @@ def _inspect_file_node(fnode: FileNode, g: PropertyGraph) -> None:
                 kind = imp.node_type
             t.add_row(imp.id, kind)
         console.print(t)
+
+
+# ---------------------------------------------------------------------------
+# ckg embed
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.option("--repo", default=".", type=click.Path(exists=True),
+              help="Repository root (default: current directory).")
+@click.option("--force", is_flag=True,
+              help="Re-embed all nodes even if already stored.")
+@click.option("--model", default="all-MiniLM-L6-v2", show_default=True,
+              help="Sentence-transformers model to use.")
+@click.pass_context
+def embed(ctx: click.Context, repo: str, force: bool, model: str) -> None:
+    """Embed all function and class nodes for semantic search.
+
+    Vectors are stored in the DuckDB cache alongside the graph and used
+    by [cyan]ckg query search[/cyan].  Running this command again is safe
+    (already-embedded nodes are skipped unless --force is given).
+    """
+    db_path: Path = ctx.obj["db_path"]
+    g = _load_or_build_graph(repo, db_path)
+    store = GraphStore(db_path)
+    embedder = NodeEmbedder(store, model_name=model)
+
+    total_eligible = sum(
+        1 for n in g.iter_nodes()
+        if isinstance(n, (FunctionNode, ClassNode))
+    )
+    console.print(
+        f"[dim]Embedding[/dim] [bold]{total_eligible}[/bold] nodes "
+        f"using [cyan]{model}[/cyan]…"
+    )
+    n_embedded = embedder.embed_all(g, force=force)
+    total_stored = embedder.embed_count()
+    if n_embedded == 0:
+        console.print(
+            f"[green]✓[/green] Nothing new to embed "
+            f"([bold]{total_stored}[/bold] nodes already embedded). "
+            "Use [cyan]--force[/cyan] to re-embed."
+        )
+    else:
+        console.print(
+            f"[green]✓[/green] Embedded [bold]{n_embedded}[/bold] node(s) "
+            f"([bold]{total_stored}[/bold] total in cache)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/ckg/embedder.py
+++ b/ckg/embedder.py
@@ -1,0 +1,306 @@
+"""Semantic embedding layer for the Code Knowledge Graph.
+
+Embeds FunctionNode and ClassNode descriptions (name + signature + docstring)
+using a local sentence-transformers model and stores the vectors in DuckDB
+alongside the graph.  Enables both pure semantic search and hybrid
+structural + semantic queries.
+
+Usage::
+
+    from ckg.store import GraphStore
+    from ckg.embedder import NodeEmbedder
+
+    store = GraphStore()
+    graph = store.load()
+
+    embedder = NodeEmbedder(store)
+    n_embedded = embedder.embed_all(graph)
+
+    # Pure semantic
+    results = embedder.search("audio transcription", top_k=5)
+    for node, score in results:
+        print(f"{score:.3f}  {node.id}")
+
+    # Hybrid: semantic rank + structural filter
+    from ckg.queries import GraphQueries
+    q = GraphQueries(graph)
+    callers = {n.id for n in q.callers("database.py::add_episode")}
+    results = embedder.search(
+        "episode storage", top_k=10,
+        node_filter=lambda n: n.id in callers,
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Sequence
+
+import numpy as np
+
+from ckg.graph import PropertyGraph
+from ckg.models import ClassNode, FunctionNode, Node
+from ckg.store import GraphStore
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "all-MiniLM-L6-v2"
+_EMBED_DDL = """
+CREATE TABLE IF NOT EXISTS embeddings (
+    node_id   TEXT PRIMARY KEY,
+    embedding TEXT NOT NULL,    -- JSON-serialised float list
+    text_used TEXT NOT NULL
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Text builder
+# ---------------------------------------------------------------------------
+
+def _node_text(node: Node) -> str | None:
+    """Return the text to embed for *node*, or None if the node should be skipped."""
+    if isinstance(node, FunctionNode):
+        parts = [node.name]
+        if node.signature:
+            parts.append(node.signature)
+        if node.docstring:
+            parts.append(node.docstring)
+        return "\n".join(parts)
+    if isinstance(node, ClassNode):
+        parts = [node.name]
+        if node.docstring:
+            parts.append(node.docstring)
+        if node.bases:
+            parts.append("inherits: " + ", ".join(node.bases))
+        return "\n".join(parts)
+    return None  # FileNode / ModuleNode — not embedded
+
+
+# ---------------------------------------------------------------------------
+# NodeEmbedder
+# ---------------------------------------------------------------------------
+
+class NodeEmbedder:
+    """Embed graph nodes and search by cosine similarity.
+
+    Parameters
+    ----------
+    store:
+        A :class:`~ckg.store.GraphStore` instance.  The embeddings table
+        is created inside the same DuckDB file as the graph.
+    model_name:
+        Sentence-transformers model identifier.  Defaults to
+        ``all-MiniLM-L6-v2`` (384-dim, ~22 MB, CPU-friendly).
+    """
+
+    def __init__(
+        self,
+        store: GraphStore,
+        model_name: str = _DEFAULT_MODEL,
+    ) -> None:
+        self._store = store
+        self._model_name = model_name
+        self._model = None  # lazy-load
+        self._ensure_table()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _ensure_table(self) -> None:
+        conn = self._store._connect()
+        conn.execute(_EMBED_DDL)
+        conn.close()
+
+    # ------------------------------------------------------------------
+    # Model (lazy)
+    # ------------------------------------------------------------------
+
+    def _get_model(self):
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer
+            self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    # ------------------------------------------------------------------
+    # Embed
+    # ------------------------------------------------------------------
+
+    def embed_all(
+        self,
+        graph: PropertyGraph,
+        force: bool = False,
+        batch_size: int = 64,
+    ) -> int:
+        """Embed all eligible nodes and persist vectors to DuckDB.
+
+        Parameters
+        ----------
+        graph:
+            The graph whose nodes to embed.
+        force:
+            If True, re-embed every node even if already stored.
+        batch_size:
+            Number of texts to send to the model at once.
+
+        Returns
+        -------
+        int
+            Number of nodes newly embedded.
+        """
+        already_stored: set[str] = set()
+        if not force:
+            already_stored = self._stored_ids()
+
+        # Collect (node, text) pairs to embed
+        to_embed: list[tuple[Node, str]] = []
+        for node in graph.iter_nodes():
+            if node.id in already_stored:
+                continue
+            text = _node_text(node)
+            if text:
+                to_embed.append((node, text))
+
+        if not to_embed:
+            return 0
+
+        model = self._get_model()
+        texts = [t for _, t in to_embed]
+        nodes_list = [n for n, _ in to_embed]
+
+        # Encode in batches
+        vectors: list[np.ndarray] = []
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            vecs = model.encode(batch, normalize_embeddings=True, show_progress_bar=False)
+            vectors.extend(vecs)
+
+        # Persist
+        conn = self._store._connect()
+        rows = [
+            (node.id, json.dumps(vec.tolist()), text)
+            for node, text, vec in zip(nodes_list, texts, vectors)
+        ]
+        conn.executemany(
+            "INSERT OR REPLACE INTO embeddings (node_id, embedding, text_used) VALUES (?, ?, ?)",
+            rows,
+        )
+        conn.close()
+        return len(rows)
+
+    def embed_node(self, node: Node) -> bool:
+        """Embed a single node and persist it.  Returns True if embedded."""
+        text = _node_text(node)
+        if text is None:
+            return False
+        model = self._get_model()
+        vec: np.ndarray = model.encode(text, normalize_embeddings=True, show_progress_bar=False)
+        conn = self._store._connect()
+        conn.execute(
+            "INSERT OR REPLACE INTO embeddings (node_id, embedding, text_used) VALUES (?, ?, ?)",
+            (node.id, json.dumps(vec.tolist()), text),
+        )
+        conn.close()
+        return True
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        graph: PropertyGraph,
+        top_k: int = 10,
+        node_filter: Callable[[Node], bool] | None = None,
+    ) -> list[tuple[Node, float]]:
+        """Return nodes most similar to *query*, sorted by cosine similarity.
+
+        Parameters
+        ----------
+        query:
+            Free-text query string.
+        graph:
+            Graph used for node lookups.
+        top_k:
+            Maximum number of results.
+        node_filter:
+            Optional callable; only nodes for which it returns True are
+            considered.  Use this to combine semantic ranking with
+            structural constraints.
+
+        Returns
+        -------
+        list of ``(node, score)`` sorted descending by score.
+        """
+        model = self._get_model()
+        q_vec: np.ndarray = model.encode(query, normalize_embeddings=True, show_progress_bar=False)
+
+        conn = self._store._connect()
+        rows = conn.execute(
+            "SELECT node_id, embedding FROM embeddings"
+        ).fetchall()
+        conn.close()
+
+        if not rows:
+            return []
+
+        # Build matrix
+        ids = [r[0] for r in rows]
+        matrix = np.array([json.loads(r[1]) for r in rows], dtype=np.float32)  # (N, D)
+
+        # Cosine similarity (vectors are already normalised)
+        scores: np.ndarray = matrix @ q_vec  # (N,)
+
+        # Rank
+        ranked = sorted(zip(ids, scores.tolist()), key=lambda x: -x[1])
+
+        results: list[tuple[Node, float]] = []
+        for node_id, score in ranked:
+            if len(results) >= top_k:
+                break
+            node = graph.get_node(node_id)
+            if node is None:
+                continue
+            if node_filter is not None and not node_filter(node):
+                continue
+            results.append((node, float(score)))
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _stored_ids(self) -> set[str]:
+        conn = self._store._connect()
+        rows = conn.execute("SELECT node_id FROM embeddings").fetchall()
+        conn.close()
+        return {r[0] for r in rows}
+
+    def embed_count(self) -> int:
+        """Return the number of nodes currently embedded in DuckDB."""
+        conn = self._store._connect()
+        count = conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+        conn.close()
+        return count
+
+    def invalidate_file(self, file_path: str) -> int:
+        """Remove all embeddings for nodes belonging to *file_path*.
+
+        Returns the number of rows deleted.
+        """
+        conn = self._store._connect()
+        # Match node_id prefix (e.g. "service.py" or "service.py::")
+        result = conn.execute(
+            "SELECT COUNT(*) FROM embeddings WHERE node_id = ? OR node_id LIKE ?",
+            (file_path, f"{file_path}::%"),
+        ).fetchone()[0]
+        conn.execute(
+            "DELETE FROM embeddings WHERE node_id = ? OR node_id LIKE ?",
+            (file_path, f"{file_path}::%"),
+        )
+        conn.close()
+        return result

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,432 @@
+"""Tests for ckg.embedder.NodeEmbedder."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ckg.embedder import NodeEmbedder, _node_text
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
+from ckg.store import GraphStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_repo(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "transcriber.py").write_text(textwrap.dedent("""\
+        \"\"\"Audio transcription utilities.\"\"\"
+
+        def transcribe_episode(audio_path: str) -> str:
+            \"\"\"Transcribe an audio file to text using Whisper.\"\"\"
+            import whisper
+            model = whisper.load_model("base")
+            result = model.transcribe(audio_path)
+            return result["text"]
+
+        def detect_language(audio_path: str) -> str:
+            \"\"\"Detect the spoken language of an audio file.\"\"\"
+            return "en"
+    """))
+    (tmp_path / "database.py").write_text(textwrap.dedent("""\
+        \"\"\"SQLite persistence for episodes.\"\"\"
+
+        class EpisodeDatabase:
+            \"\"\"Stores and retrieves podcast episode records.\"\"\"
+
+            def __init__(self, path: str) -> None:
+                self._path = path
+
+            def add_episode(self, url: str, transcript: str) -> None:
+                \"\"\"Insert a new episode into the database.\"\"\"
+                if not url:
+                    raise ValueError("url required")
+
+            def get_episode(self, url: str) -> dict:
+                \"\"\"Retrieve an episode by URL.\"\"\"
+                return {}
+
+            def list_episodes(self) -> list:
+                \"\"\"Return all stored episodes.\"\"\"
+                return []
+    """))
+    (tmp_path / "cli.py").write_text(textwrap.dedent("""\
+        \"\"\"Command-line interface for the podcast processor.\"\"\"
+        from database import EpisodeDatabase
+        from transcriber import transcribe_episode
+
+        def run(audio_path: str, db_path: str) -> None:
+            \"\"\"Transcribe and store a podcast episode.\"\"\"
+            db = EpisodeDatabase(db_path)
+            text = transcribe_episode(audio_path)
+            db.add_episode(audio_path, text)
+    """))
+    return tmp_path
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    return _make_repo(tmp_path / "repo")
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> GraphStore:
+    return GraphStore(tmp_path / "g.db")
+
+
+@pytest.fixture()
+def graph(repo: Path, store: GraphStore) -> PropertyGraph:
+    return store.build_and_save(repo)
+
+
+@pytest.fixture()
+def embedder(store: GraphStore) -> NodeEmbedder:
+    return NodeEmbedder(store)
+
+
+# ---------------------------------------------------------------------------
+# _node_text helper
+# ---------------------------------------------------------------------------
+
+class TestNodeText:
+    def test_function_uses_name(self) -> None:
+        fn = FunctionNode(
+            id="f.py::foo", name="foo", file_path="f.py",
+            line_start=1, line_end=5, signature="def foo(x: int) -> str",
+            docstring="Does foo.", return_type="str", param_count=1,
+            cyclomatic_complexity=1, is_async=False, is_method=False,
+            class_name=None,
+        )
+        text = _node_text(fn)
+        assert "foo" in text
+
+    def test_function_includes_signature(self) -> None:
+        fn = FunctionNode(
+            id="f.py::foo", name="foo", file_path="f.py",
+            line_start=1, line_end=5, signature="def foo(x: int) -> str",
+            docstring=None, return_type="str", param_count=1,
+            cyclomatic_complexity=1, is_async=False, is_method=False,
+            class_name=None,
+        )
+        assert "def foo(x: int) -> str" in _node_text(fn)
+
+    def test_function_includes_docstring(self) -> None:
+        fn = FunctionNode(
+            id="f.py::foo", name="foo", file_path="f.py",
+            line_start=1, line_end=5, signature="def foo()",
+            docstring="Handles audio transcription.", return_type=None,
+            param_count=0, cyclomatic_complexity=1, is_async=False,
+            is_method=False, class_name=None,
+        )
+        assert "audio transcription" in _node_text(fn)
+
+    def test_class_uses_name(self) -> None:
+        cls = ClassNode(
+            id="f.py::DB", name="DB", file_path="f.py",
+            line_start=1, line_end=10, bases=[], docstring=None,
+            method_count=2,
+        )
+        assert "DB" in _node_text(cls)
+
+    def test_class_includes_docstring(self) -> None:
+        cls = ClassNode(
+            id="f.py::DB", name="DB", file_path="f.py",
+            line_start=1, line_end=10, bases=["BaseDB"],
+            docstring="Manages database connections.", method_count=2,
+        )
+        text = _node_text(cls)
+        assert "database connections" in text
+
+    def test_class_includes_bases(self) -> None:
+        cls = ClassNode(
+            id="f.py::DB", name="DB", file_path="f.py",
+            line_start=1, line_end=10, bases=["BaseHandler"],
+            docstring=None, method_count=2,
+        )
+        assert "BaseHandler" in _node_text(cls)
+
+    def test_file_node_returns_none(self) -> None:
+        fnode = FileNode(id="f.py", path="f.py", line_count=10, avg_complexity=2.0)
+        assert _node_text(fnode) is None
+
+    def test_module_node_returns_none(self) -> None:
+        mnode = ModuleNode(id="os", name="os", is_stdlib=True, is_local=False)
+        assert _node_text(mnode) is None
+
+
+# ---------------------------------------------------------------------------
+# embed_all
+# ---------------------------------------------------------------------------
+
+class TestEmbedAll:
+    def test_embeds_functions_and_classes(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        n = embedder.embed_all(graph)
+        assert n > 0
+
+    def test_embed_count_matches_eligible_nodes(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        eligible = sum(
+            1 for node in graph.iter_nodes()
+            if isinstance(node, (FunctionNode, ClassNode))
+        )
+        embedder.embed_all(graph)
+        assert embedder.embed_count() == eligible
+
+    def test_idempotent_without_force(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        first = embedder.embed_all(graph)
+        second = embedder.embed_all(graph)
+        assert first > 0
+        assert second == 0  # nothing new to embed
+
+    def test_force_reembeds_all(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        count_before = embedder.embed_count()
+        re_embedded = embedder.embed_all(graph, force=True)
+        assert re_embedded == count_before
+
+    def test_vectors_stored_in_duckdb(
+        self, graph: PropertyGraph, embedder: NodeEmbedder, store: GraphStore
+    ) -> None:
+        embedder.embed_all(graph)
+        conn = store._connect()
+        rows = conn.execute("SELECT node_id, embedding FROM embeddings").fetchall()
+        conn.close()
+        assert len(rows) > 0
+        # Each embedding should be a valid JSON float list
+        vec = json.loads(rows[0][1])
+        assert isinstance(vec, list)
+        assert len(vec) == 384  # all-MiniLM-L6-v2
+
+    def test_vectors_are_unit_normalised(
+        self, graph: PropertyGraph, embedder: NodeEmbedder, store: GraphStore
+    ) -> None:
+        embedder.embed_all(graph)
+        conn = store._connect()
+        rows = conn.execute("SELECT embedding FROM embeddings LIMIT 5").fetchall()
+        conn.close()
+        for (emb_json,) in rows:
+            vec = np.array(json.loads(emb_json))
+            norm = float(np.linalg.norm(vec))
+            assert abs(norm - 1.0) < 1e-5, f"vector not unit-normalised (norm={norm})"
+
+
+# ---------------------------------------------------------------------------
+# embed_node
+# ---------------------------------------------------------------------------
+
+class TestEmbedNode:
+    def test_embeds_single_function(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        fn = graph.get_node("transcriber.py::transcribe_episode")
+        assert fn is not None
+        result = embedder.embed_node(fn)
+        assert result is True
+        assert embedder.embed_count() == 1
+
+    def test_skips_file_node(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        fnode = graph.get_node("cli.py")
+        assert fnode is not None
+        result = embedder.embed_node(fnode)
+        assert result is False
+        assert embedder.embed_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# search — relevance
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    def test_returns_top_k_results(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search("transcription", graph=graph, top_k=3)
+        assert len(results) <= 3
+
+    def test_transcription_query_finds_transcribe_episode(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search("audio transcription", graph=graph, top_k=5)
+        ids = [n.id for n, _ in results]
+        assert "transcriber.py::transcribe_episode" in ids
+
+    def test_database_query_finds_episode_database(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search("database episode storage", graph=graph, top_k=5)
+        ids = [n.id for n, _ in results]
+        assert any("database" in nid.lower() for nid in ids)
+
+    def test_scores_descending(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search("store episode", graph=graph, top_k=10)
+        scores = [s for _, s in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_scores_between_0_and_1(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search("run", graph=graph, top_k=5)
+        for _, score in results:
+            assert -1.0 <= score <= 1.0
+
+    def test_empty_db_returns_empty(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        # Don't call embed_all — DB is empty
+        results = embedder.search("anything", graph=graph, top_k=5)
+        assert results == []
+
+    def test_node_filter_restricts_results(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        # Only nodes in transcriber.py
+        results = embedder.search(
+            "audio", graph=graph, top_k=10,
+            node_filter=lambda n: getattr(n, "file_path", "") == "transcriber.py",
+        )
+        for node, _ in results:
+            assert node.file_path == "transcriber.py"
+
+    def test_node_filter_can_return_empty(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        results = embedder.search(
+            "anything", graph=graph, top_k=10,
+            node_filter=lambda n: False,
+        )
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# invalidate_file
+# ---------------------------------------------------------------------------
+
+class TestInvalidateFile:
+    def test_removes_embeddings_for_file(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        removed = embedder.invalidate_file("transcriber.py")
+        assert removed > 0
+        # Those nodes should no longer appear in search
+        results = embedder.search(
+            "transcription", graph=graph, top_k=20
+        )
+        ids = [n.id for n, _ in results]
+        assert "transcriber.py::transcribe_episode" not in ids
+
+    def test_leaves_other_files_intact(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        count_before = embedder.embed_count()
+        removed = embedder.invalidate_file("transcriber.py")
+        assert embedder.embed_count() == count_before - removed
+        # database.py nodes still present
+        results = embedder.search(
+            "episode database", graph=graph, top_k=20
+        )
+        ids = [n.id for n, _ in results]
+        assert any("database" in nid.lower() for nid in ids)
+
+    def test_invalidate_nonexistent_returns_zero(
+        self, graph: PropertyGraph, embedder: NodeEmbedder
+    ) -> None:
+        embedder.embed_all(graph)
+        removed = embedder.invalidate_file("nonexistent.py")
+        assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI — embed command and search subcommand
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_embed_command_runs(self, repo: Path, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+
+        runner = CliRunner()
+        db = str(tmp_path / "g.db")
+        result = runner.invoke(
+            cli, ["--db", db, "build", str(repo)], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            cli, ["--db", db, "embed", "--repo", str(repo)], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert "Embedded" in result.output or "Nothing new" in result.output
+
+    def test_embed_idempotent(self, repo: Path, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+
+        runner = CliRunner()
+        db = str(tmp_path / "g.db")
+        runner.invoke(cli, ["--db", db, "build", str(repo)], catch_exceptions=False)
+        runner.invoke(cli, ["--db", db, "embed", "--repo", str(repo)], catch_exceptions=False)
+
+        result = runner.invoke(
+            cli, ["--db", db, "embed", "--repo", str(repo)], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert "Nothing new" in result.output
+
+    def test_search_requires_embed_first(self, repo: Path, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+
+        runner = CliRunner()
+        db = str(tmp_path / "g.db")
+        runner.invoke(cli, ["--db", db, "build", str(repo)], catch_exceptions=False)
+
+        result = runner.invoke(
+            cli,
+            ["--db", db, "query", "search", "transcription", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0 or "No embeddings" in result.output
+
+    def test_search_returns_results(self, repo: Path, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+
+        runner = CliRunner()
+        db = str(tmp_path / "g.db")
+        runner.invoke(cli, ["--db", db, "build", str(repo)], catch_exceptions=False)
+        runner.invoke(cli, ["--db", db, "embed", "--repo", str(repo)], catch_exceptions=False)
+
+        result = runner.invoke(
+            cli,
+            ["--db", db, "query", "search", "audio transcription", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "transcribe" in result.output.lower()


### PR DESCRIPTION
## Summary

Implements **Phase 5** from PLAN.md: semantic search over the code graph, plus hybrid structural + semantic queries.

## New file: `ckg/embedder.py` — `NodeEmbedder`

```python
from ckg.store import GraphStore
from ckg.embedder import NodeEmbedder

store = GraphStore()
graph = store.load()

embedder = NodeEmbedder(store)       # lazy-loads all-MiniLM-L6-v2 on first use
n = embedder.embed_all(graph)        # embed all FunctionNode + ClassNode → DuckDB

# Pure semantic
results = embedder.search("audio transcription", graph=graph, top_k=5)
# → [(transcriber.py::AudioTranscriber, 0.661), (cli.py::transcribe, 0.583), ...]

# Hybrid: semantic rank + structural filter
from ckg.queries import GraphQueries
q = GraphQueries(graph)
callers = {n.id for n in q.callers("database.py::add_episode")}
results = embedder.search(
    "episode storage", graph=graph, top_k=10,
    node_filter=lambda n: n.id in callers,
)
```

## How it works

| Step | Detail |
|---|---|
| **Text** | `name + signature + docstring` for functions; `name + docstring + bases` for classes |
| **Model** | `all-MiniLM-L6-v2` — 384-dim, 22 MB, CPU-only, lazy-loaded |
| **Storage** | DuckDB `embeddings` table in the same `.db` file as the graph |
| **Similarity** | Cosine (`matrix @ q_vec`); vectors stored L2-normalised so dot product = cosine |
| **Idempotent** | `embed_all()` skips nodes already in table; `--force` re-embeds |

## CLI additions

```bash
# Embed all nodes (run once after build)
ckg embed --repo .

# Semantic search
ckg query search "audio transcription" --top 5

# Hybrid via node_filter in Python (CLI exposes plain search; filter is API-level)
```

## Verified against P³

```
Embedding 121 nodes using all-MiniLM-L6-v2…
✓ Embedded 121 node(s)

search "audio transcription":
  0.661  transcriber.py::AudioTranscriber      ✅ top result
  0.583  cli.py::transcribe

search "database insert episode":
  0.463  database.py::P3Database.add_episode   ✅ top result
  0.425  cli.py::episode_info

Second embed run: ✓ Nothing new to embed (121 already stored)
```

## Tests

31 new embedder tests + 159 existing = **190 total, all passing**

Test coverage:
- `_node_text` for all node types
- `embed_all` idempotency + force + vector shape + unit normalisation
- `embed_node` single node + skip FileNode
- `search` top-k, relevance, score ordering, score bounds, empty DB, node_filter
- `invalidate_file` removes embeddings for one file, leaves others
- CLI: `ckg embed`, idempotency, `ckg query search` with/without embeddings