### PR TITLE
feat: ckg export (JSON/CSV/DOT) + ckg query fan-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ ckg inspect node 'database.py::add_episode'    # full node details
 ckg stats                                      # graph summary
 ckg embed --repo .                             # build semantic search index
 ckg query search "audio transcription"         # semantic similarity search
+ckg query fan-in                               # most-called functions
 ckg watch --repo .                             # auto-rebuild on file changes
+ckg export --format json > graph.json          # export full graph
+ckg export --format csv --output ./out/        # nodes.csv + edges.csv
+ckg export --format dot | dot -Tsvg > g.svg    # Graphviz visualisation
 ```
 
 ## Installation
@@ -36,6 +40,7 @@ uv run ckg --help
 | #2 | DuckDB persistence | ✅ Done |
 | #15 | Hybrid search (semantic embeddings) | ✅ Done |
 | #18 | `ckg watch` filesystem watcher | ✅ Done |
+| #20 | `ckg export` (JSON/CSV/DOT) + `fan-in` query | ✅ Done |
 | #7 | Structural queries | ✅ Done |
 | #1 | CLI (full) | ✅ Done |
 | #3 | Eval on P³ | ✅ Done |

--- a/ckg/cli.py
+++ b/ckg/cli.py
@@ -14,6 +14,7 @@ from rich.text import Text
 from rich import box
 
 from ckg.embedder import NodeEmbedder
+from ckg.export import export_json, export_csv, export_dot
 from ckg.graph import PropertyGraph
 from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
 from ckg.queries import GraphQueries
@@ -196,7 +197,7 @@ def build(ctx: click.Context, repo: str, incremental: bool, force: bool) -> None
 
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("subcommand", type=click.Choice(
-    ["impact", "callers", "callees", "hotspots", "dead-code", "path", "raises", "search"],
+    ["impact", "callers", "callees", "hotspots", "dead-code", "path", "raises", "search", "fan-in"],
     case_sensitive=False,
 ))
 @click.argument("args", nargs=-1)
@@ -216,6 +217,7 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
       callers <name_or_id>        All callers of a function
       callees <name_or_id>        All callees of a function
       hotspots                    Top-N complexity hotspots (--top N)
+      fan-in                      Top-N most-called functions (--top N)
       dead-code                   Functions never called anywhere
       path    <file_a> <file_b>   Dependency path between two files
       raises  <ExceptionName>     Functions that raise an exception
@@ -348,6 +350,28 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
         t.add_column("Line", justify="right", width=6)
         for fn in raisers:
             t.add_row(fn.id, fn.file_path, str(fn.line_start))
+        console.print(t)
+
+    # ---- fan-in -----------------------------------------------------------
+    elif sub == "fan-in":
+        results = q.fan_in(top_k=top)
+        if not results:
+            console.print("[yellow]No functions found.[/yellow]")
+            return
+        t = Table(title=f"Top-{top} Most-Called Functions (fan-in)", box=box.SIMPLE_HEAD)
+        t.add_column("#", justify="right", width=4, style="dim")
+        t.add_column("Function", style="cyan")
+        t.add_column("File", style="dim")
+        t.add_column("Callers", justify="right", width=8)
+        t.add_column("CC", justify="right", width=4)
+        for i, (fn, count) in enumerate(results, 1):
+            t.add_row(
+                str(i),
+                fn.id,
+                fn.file_path,
+                str(count),
+                _complexity_text(fn.cyclomatic_complexity),
+            )
         console.print(t)
 
     # ---- search -----------------------------------------------------------
@@ -573,6 +597,71 @@ def _inspect_file_node(fnode: FileNode, g: PropertyGraph) -> None:
                 kind = imp.node_type
             t.add_row(imp.id, kind)
         console.print(t)
+
+
+# ---------------------------------------------------------------------------
+# ckg export
+# ---------------------------------------------------------------------------
+
+@cli.command("export")
+@click.option("--format", "fmt",
+              type=click.Choice(["json", "csv", "dot"], case_sensitive=False),
+              default="json", show_default=True,
+              help="Output format.")
+@click.option("--only",
+              type=click.Choice(["nodes", "edges", "both"], case_sensitive=False),
+              default="both", show_default=True,
+              help="What to include (JSON only).")
+@click.option("--output", "-o", default=None,
+              help="Output file path (JSON/DOT) or directory (CSV). "
+                   "Default: print to stdout (JSON/DOT) or write to current dir (CSV).")
+@click.option("--repo", default=".", type=click.Path(exists=True),
+              help="Repository root (default: current directory).")
+@click.pass_context
+def export_cmd(ctx: click.Context, fmt: str, only: str, output: str | None, repo: str) -> None:
+    """Export the knowledge graph to JSON, CSV, or Graphviz DOT.
+
+    \b
+    Formats:
+      json   Single JSON object with 'nodes' and 'edges' arrays (stdout or -o file)
+      csv    Two files: nodes.csv + edges.csv  (written to -o dir, default: .)
+      dot    Graphviz DOT language  (stdout or -o file; render with: dot -Tpng)
+
+    \b
+    Examples:
+      ckg export --format json > graph.json
+      ckg export --format csv --output ./out/
+      ckg export --format dot | dot -Tsvg > graph.svg
+      ckg export --format json --only nodes > nodes.json
+    """
+    db_path: Path = ctx.obj["db_path"]
+    g = _load_or_build_graph(repo, db_path)
+
+    fmt = fmt.lower()
+
+    if fmt == "json":
+        text = export_json(g, only=only)  # type: ignore[arg-type]
+        if output:
+            Path(output).write_text(text, encoding="utf-8")
+            console.print(f"[green]✓[/green] Written to [cyan]{output}[/cyan]")
+        else:
+            click.echo(text)
+
+    elif fmt == "csv":
+        out_dir = Path(output) if output else Path(".")
+        nodes_path, edges_path = export_csv(g, output_dir=out_dir)
+        console.print(
+            f"[green]✓[/green] Nodes → [cyan]{nodes_path}[/cyan]  "
+            f"Edges → [cyan]{edges_path}[/cyan]"
+        )
+
+    elif fmt == "dot":
+        text = export_dot(g)
+        if output:
+            Path(output).write_text(text, encoding="utf-8")
+            console.print(f"[green]✓[/green] Written to [cyan]{output}[/cyan]")
+        else:
+            click.echo(text)
 
 
 # ---------------------------------------------------------------------------

--- a/ckg/export.py
+++ b/ckg/export.py
@@ -1,0 +1,302 @@
+"""Export a PropertyGraph to standard interchange formats.
+
+Supported formats
+-----------------
+json
+    Single JSON object with ``nodes`` and ``edges`` arrays.  Every scalar
+    field from the dataclass is included; list fields (e.g. ``bases``) are
+    kept as JSON arrays.
+
+csv
+    Two files: ``nodes.csv`` and ``edges.csv``.  Written to *output_dir*
+    (default: current directory).  List fields are serialised as
+    semicolon-separated strings.
+
+dot
+    Graphviz DOT language.  Directed graph; node label = name; edge label =
+    edge type.  CALLS edges are solid blue, IMPORTS dashed grey, DEFINES /
+    CONTAINS light green, INHERITS orange, RAISES red.
+
+Usage::
+
+    from ckg.graph import PropertyGraph
+    from ckg.export import export_json, export_csv, export_dot
+
+    g = PropertyGraph()
+    g.build_from_directory("my_project/")
+
+    json_str = export_json(g)
+    export_csv(g, output_dir=".")
+    dot_str  = export_dot(g)
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import io
+from pathlib import Path
+from typing import Literal
+
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode, Node
+
+
+# ---------------------------------------------------------------------------
+# Node → dict
+# ---------------------------------------------------------------------------
+
+def _node_to_dict(node: Node) -> dict:
+    """Serialise a node dataclass to a plain dict."""
+    d: dict = {
+        "id": node.id,
+        "type": node.node_type,
+    }
+    if isinstance(node, FunctionNode):
+        d.update({
+            "name": node.name,
+            "file": node.file_path,
+            "line_start": node.line_start,
+            "line_end": node.line_end,
+            "signature": node.signature,
+            "docstring": node.docstring,
+            "return_type": node.return_type,
+            "param_count": node.param_count,
+            "cyclomatic_complexity": node.cyclomatic_complexity,
+            "is_async": node.is_async,
+            "is_method": node.is_method,
+            "class_name": node.class_name,
+        })
+    elif isinstance(node, ClassNode):
+        d.update({
+            "name": node.name,
+            "file": node.file_path,
+            "line_start": node.line_start,
+            "line_end": node.line_end,
+            "bases": node.bases,
+            "docstring": node.docstring,
+            "method_count": node.method_count,
+        })
+    elif isinstance(node, FileNode):
+        d.update({
+            "path": node.path,
+            "line_count": node.line_count,
+            "avg_complexity": node.avg_complexity,
+        })
+    elif isinstance(node, ModuleNode):
+        d.update({
+            "name": node.name,
+            "is_stdlib": node.is_stdlib,
+            "is_local": node.is_local,
+        })
+    return d
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+def export_json(
+    graph: PropertyGraph,
+    *,
+    only: Literal["nodes", "edges", "both"] = "both",
+    indent: int = 2,
+) -> str:
+    """Return a JSON string representing the graph.
+
+    Parameters
+    ----------
+    graph:
+        The graph to export.
+    only:
+        ``"nodes"`` — only the nodes array; ``"edges"`` — only edges;
+        ``"both"`` (default) — full ``{nodes, edges}`` object.
+    indent:
+        JSON indentation level.
+    """
+    nodes_list = sorted(
+        (_node_to_dict(n) for n in graph.iter_nodes()),
+        key=lambda d: d["id"],
+    )
+    edges_list = [
+        {
+            "src": src,
+            "dst": dst,
+            "type": data.get("edge_type", ""),
+            "weight": data.get("weight", 1),
+            "line": data.get("line"),
+        }
+        for src, dst, data in sorted(
+            graph.nx_graph.edges(data=True),
+            key=lambda t: (t[0], t[1], t[2].get("edge_type", "")),
+        )
+    ]
+
+    if only == "nodes":
+        payload = nodes_list
+    elif only == "edges":
+        payload = edges_list
+    else:
+        payload = {"nodes": nodes_list, "edges": edges_list}
+
+    return json.dumps(payload, indent=indent, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+# Canonical column order for each file
+_NODE_COLUMNS = [
+    "id", "type", "name", "file", "line_start", "line_end",
+    "signature", "docstring", "return_type", "param_count",
+    "cyclomatic_complexity", "is_async", "is_method", "class_name",
+    # class extras
+    "bases", "method_count",
+    # file extras
+    "path", "line_count", "avg_complexity",
+    # module extras
+    "is_stdlib", "is_local",
+]
+_EDGE_COLUMNS = ["src", "dst", "type", "weight", "line"]
+
+
+def _flatten_for_csv(d: dict) -> dict:
+    """Convert list fields to semicolon-joined strings for CSV export."""
+    out = {}
+    for k, v in d.items():
+        if isinstance(v, list):
+            out[k] = ";".join(str(x) for x in v)
+        elif v is None:
+            out[k] = ""
+        else:
+            out[k] = v
+    return out
+
+
+def export_csv(
+    graph: PropertyGraph,
+    *,
+    output_dir: str | Path = ".",
+) -> tuple[Path, Path]:
+    """Write ``nodes.csv`` and ``edges.csv`` to *output_dir*.
+
+    Returns
+    -------
+    tuple of (nodes_path, edges_path)
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    nodes_path = out / "nodes.csv"
+    edges_path = out / "edges.csv"
+
+    # Nodes
+    nodes_rows = sorted(
+        (_flatten_for_csv(_node_to_dict(n)) for n in graph.iter_nodes()),
+        key=lambda d: d["id"],
+    )
+    with nodes_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=_NODE_COLUMNS,
+            extrasaction="ignore",
+            restval="",
+        )
+        writer.writeheader()
+        writer.writerows(nodes_rows)
+
+    # Edges
+    edges_rows = [
+        {
+            "src": src,
+            "dst": dst,
+            "type": data.get("edge_type", ""),
+            "weight": data.get("weight", 1),
+            "line": data.get("line", ""),
+        }
+        for src, dst, data in sorted(
+            graph.nx_graph.edges(data=True),
+            key=lambda t: (t[0], t[1], t[2].get("edge_type", "")),
+        )
+    ]
+    with edges_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=_EDGE_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(edges_rows)
+
+    return nodes_path, edges_path
+
+
+# ---------------------------------------------------------------------------
+# DOT (Graphviz)
+# ---------------------------------------------------------------------------
+
+# Edge style by type
+_EDGE_STYLES: dict[str, str] = {
+    "CALLS":    'color="blue" style="solid"',
+    "IMPORTS":  'color="gray60" style="dashed"',
+    "DEFINES":  'color="darkgreen" style="solid"',
+    "CONTAINS": 'color="green3" style="solid"',
+    "INHERITS": 'color="darkorange" style="solid"',
+    "RAISES":   'color="red" style="solid"',
+}
+_DEFAULT_EDGE_STYLE = 'color="black"'
+
+# Node shape by type
+_NODE_SHAPES: dict[str, str] = {
+    "function": "ellipse",
+    "class":    "box",
+    "file":     "folder",
+    "module":   "cylinder",
+}
+_DEFAULT_SHAPE = "ellipse"
+
+
+def _dot_id(node_id: str) -> str:
+    """Escape a node ID for use as a DOT identifier."""
+    return '"' + node_id.replace('"', '\\"') + '"'
+
+
+def export_dot(graph: PropertyGraph) -> str:
+    """Return a Graphviz DOT string for the graph.
+
+    Produces a directed graph (``digraph``) with:
+    - Node labels = bare name; shape encodes node type
+    - Edge labels = edge type; colour/style encodes edge type
+    - CALLS edges in blue, IMPORTS dashed grey, DEFINES/CONTAINS green,
+      INHERITS orange, RAISES red
+    """
+    buf = io.StringIO()
+    buf.write("digraph ckg {\n")
+    buf.write('  graph [rankdir="LR" fontname="Helvetica"];\n')
+    buf.write('  node  [fontname="Helvetica" fontsize=10];\n')
+    buf.write('  edge  [fontname="Helvetica" fontsize=8];\n\n')
+
+    # Nodes
+    for node in sorted(graph.iter_nodes(), key=lambda n: n.id):
+        shape = _NODE_SHAPES.get(node.node_type, _DEFAULT_SHAPE)
+        label = getattr(node, "name", node.id)
+        # Escape special chars in label
+        label = label.replace('"', '\\"').replace("\n", "\\n")
+        buf.write(
+            f"  {_dot_id(node.id)} "
+            f'[label="{label}" shape="{shape}"];\n'
+        )
+
+    buf.write("\n")
+
+    # Edges
+    for src, dst, data in sorted(
+        graph.nx_graph.edges(data=True),
+        key=lambda t: (t[0], t[1], t[2].get("edge_type", "")),
+    ):
+        etype = data.get("edge_type", "")
+        style = _EDGE_STYLES.get(etype, _DEFAULT_EDGE_STYLE)
+        label = etype.replace('"', '\\"')
+        buf.write(
+            f"  {_dot_id(src)} -> {_dot_id(dst)} "
+            f'[label="{label}" {style}];\n'
+        )
+
+    buf.write("}\n")
+    return buf.getvalue()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,454 @@
+"""Tests for ckg.export and the ckg export / ckg query fan-in CLI commands."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ckg.export import export_csv, export_dot, export_json, _node_to_dict
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode, FileNode, ModuleNode
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+def _make_graph(tmp_path: Path) -> PropertyGraph:
+    """Small three-file graph for export tests."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "db.py").write_text(textwrap.dedent("""\
+        class Database:
+            \"\"\"In-memory store.\"\"\"
+            def add(self, key: str, value: int) -> None:
+                \"\"\"Add a key/value pair.\"\"\"
+                self._data[key] = value
+
+            def get(self, key: str) -> int:
+                return self._data[key]
+    """))
+    (tmp_path / "service.py").write_text(textwrap.dedent("""\
+        from db import Database
+        import os
+
+        def create(db, key, value):
+            db.add(key, value)
+
+        def fetch(db, key):
+            return db.get(key)
+
+        def unused():
+            pass
+    """))
+    (tmp_path / "cli.py").write_text(textwrap.dedent("""\
+        from service import create, fetch
+
+        def run(db, key, value):
+            create(db, key, value)
+            return fetch(db, key)
+    """))
+    g = PropertyGraph()
+    g.build_from_directory(tmp_path)
+    return g
+
+
+@pytest.fixture()
+def graph(tmp_path: Path) -> PropertyGraph:
+    return _make_graph(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _node_to_dict
+# ---------------------------------------------------------------------------
+
+class TestNodeToDict:
+    def test_function_node_fields(self) -> None:
+        fn = FunctionNode(
+            id="f.py::foo", name="foo", file_path="f.py",
+            line_start=1, line_end=5, signature="def foo(x: int) -> str",
+            docstring="Does foo.", return_type="str", param_count=1,
+            cyclomatic_complexity=2, is_async=True, is_method=False,
+            class_name=None,
+        )
+        d = _node_to_dict(fn)
+        assert d["id"] == "f.py::foo"
+        assert d["type"] == "function"
+        assert d["name"] == "foo"
+        assert d["signature"] == "def foo(x: int) -> str"
+        assert d["return_type"] == "str"
+        assert d["is_async"] is True
+        assert d["cyclomatic_complexity"] == 2
+
+    def test_class_node_fields(self) -> None:
+        cls = ClassNode(
+            id="f.py::Bar", name="Bar", file_path="f.py",
+            line_start=1, line_end=20, bases=["Base"],
+            docstring="A class.", method_count=3,
+        )
+        d = _node_to_dict(cls)
+        assert d["type"] == "class"
+        assert d["bases"] == ["Base"]
+        assert d["method_count"] == 3
+
+    def test_file_node_fields(self) -> None:
+        fnode = FileNode(id="f.py", path="f.py", line_count=42, avg_complexity=3.5)
+        d = _node_to_dict(fnode)
+        assert d["type"] == "file"
+        assert d["line_count"] == 42
+        assert d["avg_complexity"] == 3.5
+
+    def test_module_node_fields(self) -> None:
+        m = ModuleNode(id="os", name="os", is_stdlib=True, is_local=False)
+        d = _node_to_dict(m)
+        assert d["type"] == "module"
+        assert d["is_stdlib"] is True
+        assert d["is_local"] is False
+
+
+# ---------------------------------------------------------------------------
+# export_json
+# ---------------------------------------------------------------------------
+
+class TestExportJson:
+    def test_returns_valid_json(self, graph: PropertyGraph) -> None:
+        text = export_json(graph)
+        data = json.loads(text)
+        assert "nodes" in data
+        assert "edges" in data
+
+    def test_nodes_count(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        assert len(data["nodes"]) == graph.node_count()
+
+    def test_edges_count(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        assert len(data["edges"]) == graph.edge_count()
+
+    def test_node_has_required_fields(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        for node in data["nodes"]:
+            assert "id" in node
+            assert "type" in node
+
+    def test_edge_has_required_fields(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        for edge in data["edges"]:
+            assert "src" in edge
+            assert "dst" in edge
+            assert "type" in edge
+
+    def test_only_nodes(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph, only="nodes"))
+        assert isinstance(data, list)
+        assert all("id" in n for n in data)
+
+    def test_only_edges(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph, only="edges"))
+        assert isinstance(data, list)
+        assert all("src" in e for e in data)
+
+    def test_function_node_signature_present(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        fn_nodes = [n for n in data["nodes"] if n["type"] == "function"]
+        assert fn_nodes, "expected at least one function node"
+        # signature field should be present (may be empty string but not missing)
+        assert all("signature" in n for n in fn_nodes)
+
+    def test_class_bases_is_list(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        cls_nodes = [n for n in data["nodes"] if n["type"] == "class"]
+        for cls in cls_nodes:
+            assert isinstance(cls.get("bases", []), list)
+
+    def test_nodes_sorted_by_id(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        ids = [n["id"] for n in data["nodes"]]
+        assert ids == sorted(ids)
+
+    def test_calls_edges_present(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        types = {e["type"] for e in data["edges"]}
+        assert "CALLS" in types
+
+    def test_imports_edges_present(self, graph: PropertyGraph) -> None:
+        data = json.loads(export_json(graph))
+        types = {e["type"] for e in data["edges"]}
+        assert "IMPORTS" in types
+
+
+# ---------------------------------------------------------------------------
+# export_csv
+# ---------------------------------------------------------------------------
+
+class TestExportCsv:
+    def test_creates_two_files(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        nodes_p, edges_p = export_csv(graph, output_dir=out)
+        assert nodes_p.exists()
+        assert edges_p.exists()
+
+    def test_nodes_csv_row_count(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        nodes_p, _ = export_csv(graph, output_dir=out)
+        with nodes_p.open(encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == graph.node_count()
+
+    def test_edges_csv_row_count(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        _, edges_p = export_csv(graph, output_dir=out)
+        with edges_p.open(encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == graph.edge_count()
+
+    def test_nodes_csv_has_id_column(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        nodes_p, _ = export_csv(graph, output_dir=out)
+        with nodes_p.open(encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            assert "id" in (reader.fieldnames or [])
+
+    def test_edges_csv_has_src_dst_type(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        _, edges_p = export_csv(graph, output_dir=out)
+        with edges_p.open(encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for col in ("src", "dst", "type"):
+                assert col in (reader.fieldnames or [])
+
+    def test_list_fields_semicolon_joined(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        nodes_p, _ = export_csv(graph, output_dir=out)
+        with nodes_p.open(encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        cls_rows = [r for r in rows if r["type"] == "class"]
+        # bases should not contain JSON brackets — should be plain text or empty
+        for row in cls_rows:
+            assert "[" not in row.get("bases", "")
+            assert "]" not in row.get("bases", "")
+
+    def test_creates_output_dir_if_missing(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "deep" / "nested" / "out"
+        assert not out.exists()
+        export_csv(graph, output_dir=out)
+        assert out.exists()
+
+    def test_returns_correct_paths(self, graph: PropertyGraph, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        nodes_p, edges_p = export_csv(graph, output_dir=out)
+        assert nodes_p.name == "nodes.csv"
+        assert edges_p.name == "edges.csv"
+
+
+# ---------------------------------------------------------------------------
+# export_dot
+# ---------------------------------------------------------------------------
+
+class TestExportDot:
+    def test_starts_with_digraph(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        assert dot.strip().startswith("digraph")
+
+    def test_ends_with_closing_brace(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        assert dot.strip().endswith("}")
+
+    def test_contains_node_ids(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        # At least one function node ID should appear
+        assert "service.py::create" in dot
+
+    def test_contains_edge_arrows(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        assert " -> " in dot
+
+    def test_calls_edges_blue(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        # There should be at least one CALLS edge coloured blue
+        assert 'color="blue"' in dot
+
+    def test_imports_edges_dashed(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        assert 'style="dashed"' in dot
+
+    def test_all_node_ids_present(self, graph: PropertyGraph) -> None:
+        dot = export_dot(graph)
+        for node in graph.iter_nodes():
+            assert node.id in dot
+
+    def test_valid_dot_structure(self, graph: PropertyGraph) -> None:
+        """Basic structural validity: balanced braces, -> present."""
+        dot = export_dot(graph)
+        assert dot.count("{") == dot.count("}")
+        assert "->" in dot
+
+
+# ---------------------------------------------------------------------------
+# CLI — ckg export
+# ---------------------------------------------------------------------------
+
+class TestExportCLI:
+    def _build_db(self, tmp_path: Path) -> tuple[Path, Path]:
+        from ckg.store import GraphStore
+        repo = tmp_path / "repo"
+        _make_graph(repo)  # writes files into repo
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+        return repo, db
+
+    def test_export_json_stdout(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "export", "--format", "json", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # Strip Rich console preamble before the JSON payload
+        json_start = result.output.index("{")
+        data = json.loads(result.output[json_start:])
+        assert "nodes" in data
+        assert "edges" in data
+
+    def test_export_json_to_file(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        out_file = str(tmp_path / "graph.json")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "export", "--format", "json",
+             "--output", out_file, "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        data = json.loads(Path(out_file).read_text())
+        assert "nodes" in data
+
+    def test_export_csv_creates_files(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        out_dir = str(tmp_path / "csv_out")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "export", "--format", "csv",
+             "--output", out_dir, "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert (tmp_path / "csv_out" / "nodes.csv").exists()
+        assert (tmp_path / "csv_out" / "edges.csv").exists()
+
+    def test_export_dot_stdout(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "export", "--format", "dot", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "digraph" in result.output
+        assert "->" in result.output
+
+    def test_export_json_only_nodes(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "export", "--format", "json",
+             "--only", "nodes", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        json_start = result.output.index("[")
+        data = json.loads(result.output[json_start:])
+        assert isinstance(data, list)
+        assert all("id" in n for n in data)
+
+    def test_export_json_only_edges(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "export", "--format", "json",
+             "--only", "edges", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        json_start = result.output.index("[")
+        data = json.loads(result.output[json_start:])
+        assert isinstance(data, list)
+        assert all("src" in e for e in data)
+
+
+# ---------------------------------------------------------------------------
+# CLI — ckg query fan-in
+# ---------------------------------------------------------------------------
+
+class TestFanInCLI:
+    def _build_db(self, tmp_path: Path) -> tuple[Path, Path]:
+        from ckg.store import GraphStore
+        repo = tmp_path / "repo"
+        _make_graph(repo)
+        db = tmp_path / "g.db"
+        store = GraphStore(db)
+        store.build_and_save(repo)
+        return repo, db
+
+    def test_fan_in_returns_results(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "query", "fan-in", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # create and fetch are called by run → both should appear
+        assert "create" in result.output or "fetch" in result.output
+
+    def test_fan_in_top_limits_output(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "query", "fan-in", "--top", "2", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "Top-2" in result.output
+
+    def test_fan_in_shows_caller_count(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--db", str(db), "query", "fan-in", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # Should display a numeric caller count in the table
+        assert re.search(r"\b[0-9]+\b", result.output)


### PR DESCRIPTION
## Summary

Two closely related gaps closed: a full graph export system (making ckg composable with any other tool) and the `fan-in` query that already existed in code but was never reachable from the CLI.

## `ckg export`

```bash
ckg export --format json > graph.json              # full graph
ckg export --format json --only nodes > nodes.json # nodes only (for LLM context)
ckg export --format csv --output ./out/            # nodes.csv + edges.csv
ckg export --format dot | dot -Tsvg > graph.svg    # Graphviz visualisation
```

### JSON schema
```json
{
  "nodes": [
    {"id": "database.py::P3Database.add_episode", "type": "function",
     "name": "add_episode", "file": "database.py", "line_start": 151,
     "cyclomatic_complexity": 12, "signature": "def P3Database.add_episode(...)", ...}
  ],
  "edges": [
    {"src": "downloader.py::process_feed", "dst": "add_episode", "type": "CALLS", "weight": 1}
  ]
}
```

### DOT style
- **Node shape** encodes type: function=ellipse, class=box, file=folder, module=cylinder
- **Edge colour** encodes type: CALLS=blue, IMPORTS=dashed-grey, DEFINES/CONTAINS=green, INHERITS=orange, RAISES=red

## `ckg query fan-in`

```bash
ckg query fan-in           # top-10 most-called functions
ckg query fan-in --top 5
```

`GraphQueries.fan_in()` existed since issue #7 but was never wired to the CLI.

## Verified against P³

| Format | Result |
|---|---|
| JSON | 171 nodes, 952 edges — exact match |
| CSV | nodes.csv: 172 lines, edges.csv: 953 lines |
| DOT | Valid `digraph`, all node IDs present, edge colours correct |
| fan-in | interrogator.py as hub (4 callers); correct ranking |

## Tests

41 new tests + 219 existing = **260 total, all passing**

Coverage:
- `_node_to_dict` for all 4 node types
- `export_json`: valid JSON, node/edge counts, field presence, only=nodes/edges, sorted IDs, CALLS/IMPORTS edge types
- `export_csv`: two files created, row counts, column names, list-field serialisation, dir creation, return values
- `export_dot`: digraph syntax, node IDs present, edge arrows, blue CALLS, dashed IMPORTS, balanced braces
- CLI: json/csv/dot stdout + file output, only=nodes/edges, fan-in results/top/count