### PR TITLE
feat: decorator capture + transitive-deps/transitive-callers queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ ckg query file-fan-in                          # most-imported files
 ckg query async                                # all async functions
 ckg query inherits BaseModel                   # direct subclasses
 ckg query param-type datetime                  # functions with datetime param
+ckg query decorator "app.get"                  # all FastAPI GET routes
+ckg query decorator "click.command"            # all Click commands
+ckg query transitive-deps cli.py               # full import closure of a file
+ckg query transitive-callers add_episode       # every function that calls it
 ckg watch --repo .                             # auto-rebuild on file changes
 ckg export --format json > graph.json          # export full graph
 ckg export --format csv --output ./out/        # nodes.csv + edges.csv
@@ -46,6 +50,7 @@ uv run ckg --help
 | #18 | `ckg watch` filesystem watcher | ✅ Done |
 | #20 | `ckg export` (JSON/CSV/DOT) + `fan-in` query | ✅ Done |
 | #22 | Structured params + async/inherits/param-type/file-fan-in queries | ✅ Done |
+| #24 | Decorator capture + transitive-deps/transitive-callers queries | ✅ Done |
 | #7 | Structural queries | ✅ Done |
 | #1 | CLI (full) | ✅ Done |
 | #3 | Eval on P³ | ✅ Done |

--- a/ckg/cli.py
+++ b/ckg/cli.py
@@ -198,7 +198,8 @@ def build(ctx: click.Context, repo: str, incremental: bool, force: bool) -> None
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("subcommand", type=click.Choice(
     ["impact", "callers", "callees", "hotspots", "dead-code", "path", "raises",
-     "search", "fan-in", "async", "inherits", "param-type", "file-fan-in"],
+     "search", "fan-in", "async", "inherits", "param-type", "file-fan-in",
+     "decorator", "transitive-deps", "transitive-callers"],
     case_sensitive=False,
 ))
 @click.argument("args", nargs=-1)
@@ -223,8 +224,11 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
       dead-code                       Functions never called anywhere
       async                           All async functions
       inherits    <ClassName>         Direct subclasses of a class
-      param-type  <TypeAnnotation>    Functions with a given param type
-      path        <file_a> <file_b>   Dependency path between two files
+      param-type         <TypeAnnotation>    Functions with a given param type
+      decorator          <pattern>           Functions with matching decorator
+      transitive-deps    <file>              All transitive imports of a file
+      transitive-callers <name_or_id>        All functions that eventually call it
+      path               <file_a> <file_b>   Dependency path between two files
       raises      <ExceptionName>     Functions that raise an exception
       search      <query text>        Semantic similarity search over nodes
     """
@@ -455,6 +459,84 @@ def query(ctx: click.Context, subcommand: str, args: tuple[str, ...], repo: str,
             t.add_row(fn.id, fn.file_path, matching)
         console.print(t)
 
+    # ---- decorator --------------------------------------------------------
+    elif sub == "decorator":
+        if not args:
+            console.print("[red]Error:[/red] Usage: ckg query decorator <pattern>")
+            sys.exit(1)
+        pattern = " ".join(args)
+        fns = q.functions_with_decorator(pattern)
+        if not fns:
+            console.print(
+                f"[yellow]No functions found with decorator matching[/yellow] "
+                f"[cyan]{pattern}[/cyan]"
+            )
+            return
+        t = Table(
+            title=f'Functions decorated with "{pattern}"',
+            box=box.SIMPLE_HEAD,
+        )
+        t.add_column("Function", style="cyan")
+        t.add_column("File", style="dim")
+        t.add_column("Line", justify="right", width=6)
+        t.add_column("Decorator(s)", style="dim")
+        for fn in fns:
+            matching = "  |  ".join(
+                d for d in fn.decorators if pattern in d
+            )
+            t.add_row(fn.id, fn.file_path, str(fn.line_start), matching)
+        console.print(t)
+
+    # ---- transitive-deps --------------------------------------------------
+    elif sub == "transitive-deps":
+        [file_path] = _require_arg(args, 1, "Usage: ckg query transitive-deps <file>")
+        deps = q.transitive_deps(file_path)
+        if not deps:
+            console.print(
+                f"[yellow]No transitive dependencies found for[/yellow] "
+                f"[cyan]{file_path}[/cyan]"
+            )
+            return
+        # Separate local files from external modules
+        local = sorted(d for d in deps if g.get_node(d) is not None
+                       and hasattr(g.get_node(d), "path"))
+        external = sorted(d for d in deps if d not in local)
+        t = Table(
+            title=f"Transitive dependencies of {file_path} ({len(deps)} total)",
+            box=box.SIMPLE_HEAD,
+        )
+        t.add_column("Dependency", style="cyan")
+        t.add_column("Kind", style="dim", width=12)
+        for d in local:
+            t.add_row(d, "local file")
+        for d in external:
+            node = g.get_node(d)
+            kind = "stdlib" if (hasattr(node, "is_stdlib") and node.is_stdlib) else "external"
+            t.add_row(d, kind)
+        console.print(t)
+
+    # ---- transitive-callers -----------------------------------------------
+    elif sub == "transitive-callers":
+        [node_id] = _require_arg(args, 1, "Usage: ckg query transitive-callers <name_or_id>")
+        callers = q.transitive_callers(node_id)
+        if not callers:
+            console.print(
+                f"[yellow]No callers found for[/yellow] [cyan]{node_id}[/cyan]"
+            )
+            return
+        t = Table(
+            title=f"All transitive callers of {node_id} ({len(callers)} total)",
+            box=box.SIMPLE_HEAD,
+        )
+        t.add_column("Caller", style="cyan")
+        t.add_column("File", style="dim")
+        t.add_column("Line", justify="right", width=6)
+        t.add_column("CC", justify="right", width=4)
+        for fn in callers:
+            t.add_row(fn.id, fn.file_path, str(fn.line_start),
+                      _complexity_text(fn.cyclomatic_complexity))
+        console.print(t)
+
     # ---- search -----------------------------------------------------------
     elif sub == "search":
         if not args:
@@ -551,6 +633,8 @@ def _inspect_function(fn: FunctionNode, g: PropertyGraph, q: GraphQueries) -> No
     props.add_row("Signature", Text(fn.signature, style="cyan"))
     props.add_row("File", fn.file_path)
     props.add_row("Lines", f"{fn.line_start}–{fn.line_end}")
+    if fn.decorators:
+        props.add_row("Decorators", "  |  ".join(fn.decorators))
     props.add_row("Async", "yes" if fn.is_async else "no")
     props.add_row("Method", f"yes ({fn.class_name})" if fn.is_method else "no")
     if fn.params:

--- a/ckg/models.py
+++ b/ckg/models.py
@@ -52,6 +52,7 @@ class FunctionNode:
     class_name: str | None       # set when this is a method
     param_count: int = 0
     params: list[ParamInfo] = field(default_factory=list)
+    decorators: list[str] = field(default_factory=list)  # ast.unparse of each decorator
 
     node_type: NodeType = "function"
 
@@ -66,6 +67,7 @@ class ClassNode:
     bases: list[str]
     docstring: str | None
     method_count: int = 0
+    decorators: list[str] = field(default_factory=list)  # ast.unparse of each decorator
 
     node_type: NodeType = "class"
 

--- a/ckg/parsers/python.py
+++ b/ckg/parsers/python.py
@@ -339,6 +339,7 @@ class _FileParser(ast.NodeVisitor):
             bases=bases,
             docstring=docstring,
             method_count=len(method_names),
+            decorators=[ast.unparse(d) for d in node.decorator_list],
         )
         self.classes.append(cls)
 
@@ -383,6 +384,7 @@ class _FileParser(ast.NodeVisitor):
         complexity = _cyclomatic_complexity(node)
         param_count = len(node.args.args) + len(node.args.posonlyargs) + len(node.args.kwonlyargs)
         params = _build_params(node)
+        decorators = [ast.unparse(d) for d in node.decorator_list]
 
         fn = FunctionNode(
             id=func_id,
@@ -399,6 +401,7 @@ class _FileParser(ast.NodeVisitor):
             class_name=class_name,
             param_count=param_count,
             params=params,
+            decorators=decorators,
         )
         self.functions.append(fn)
 

--- a/ckg/queries.py
+++ b/ckg/queries.py
@@ -409,7 +409,149 @@ class GraphQueries:
         ]
 
     # ------------------------------------------------------------------
-    # 9. Async functions
+    # 9. Functions / classes with a given decorator
+    # ------------------------------------------------------------------
+
+    def functions_with_decorator(
+        self,
+        pattern: str,
+        *,
+        substring: bool = True,
+    ) -> list[FunctionNode]:
+        """Return functions that have at least one decorator matching *pattern*.
+
+        Parameters
+        ----------
+        pattern:
+            Decorator string to search for (e.g. ``\"app.get\"``,
+            ``\"click.command\"``, ``\"staticmethod\"``).
+        substring:
+            If True (default), match when *pattern* appears anywhere in
+            the decorator string.  Set to False for exact matching.
+        """
+        result: list[FunctionNode] = []
+        for node in self._g._nodes.values():
+            if not isinstance(node, FunctionNode):
+                continue
+            for dec in node.decorators:
+                matched = pattern in dec if substring else dec == pattern
+                if matched:
+                    result.append(node)
+                    break
+        return sorted(result, key=lambda f: f.id)
+
+    # ------------------------------------------------------------------
+    # 10. Transitive dependency closure (file-level)
+    # ------------------------------------------------------------------
+
+    def transitive_deps(self, file_path: str) -> set[str]:
+        """Return all nodes reachable from *file_path* via IMPORTS edges.
+
+        This is the full transitive closure — everything the file (and its
+        imports) ultimately depend on.
+
+        Local modules and their corresponding FileNodes are treated as the
+        same node for traversal purposes: a local ``ModuleNode("service")``
+        is bridged to ``FileNode("service.py")`` so that ``service.py``'s
+        own imports are followed transitively.
+
+        Parameters
+        ----------
+        file_path:
+            Relative file path (e.g. ``\"cli.py\"``) or bare module name.
+
+        Returns
+        -------
+        set of node IDs (file paths and module names) that *file_path*
+        transitively imports.  The starting node itself is excluded.
+        """
+        from pathlib import Path as _Path
+
+        # Build stem → FileNode.id mapping for local module bridging
+        stem_to_file_id: dict[str, str] = {}
+        for nid, node in self._g._nodes.items():
+            if isinstance(node, FileNode):
+                stem = _Path(node.path).stem
+                stem_to_file_id[stem] = nid
+
+        # Build enriched imports DiGraph that bridges ModuleNode → FileNode
+        imports_view = nx.DiGraph()
+        for s, d, data in self._g.nx_graph.edges(data=True):
+            if data.get("edge_type") != "IMPORTS":
+                continue
+            imports_view.add_edge(s, d)
+            # If d is a local module name, also add edge d → d's FileNode
+            # so traversal continues into that file's own imports
+            if d in stem_to_file_id and d != stem_to_file_id[d]:
+                imports_view.add_edge(d, stem_to_file_id[d])
+
+        # Resolve the starting node
+        src = file_path
+        if src not in imports_view:
+            stem = src[:-3] if src.endswith(".py") else src
+            if stem in imports_view:
+                src = stem
+
+        if src not in imports_view:
+            return set()
+
+        reachable = nx.descendants(imports_view, src)
+        # Remove synthetic bridge nodes that are file aliases of module nodes
+        # we already have; keep both module name and file path for clarity
+        return reachable
+
+    # ------------------------------------------------------------------
+    # 11. Transitive callers (unbounded BFS upstream)
+    # ------------------------------------------------------------------
+
+    def transitive_callers(self, node_id: str) -> list[FunctionNode]:
+        """Return *all* functions that eventually call *node_id* (unbounded).
+
+        Unlike :meth:`impact_radius`, which is bounded to a fixed depth,
+        this performs a full BFS over CALLS in-edges and returns every
+        function reachable upstream.
+
+        Parameters
+        ----------
+        node_id:
+            Full node ID or bare function name (resolved if unambiguous).
+
+        Returns
+        -------
+        list of :class:`~ckg.models.FunctionNode` sorted by ID.
+        """
+        node_id = self._resolve_id(node_id)
+        node = self._g.get_node(node_id)
+        bare_name = node.name if isinstance(node, FunctionNode) else node_id
+
+        visited: set[str] = {node_id}
+        if bare_name != node_id:
+            visited.add(bare_name)
+        queue: list[str] = [node_id, bare_name] if bare_name != node_id else [node_id]
+        result: dict[str, FunctionNode] = {}
+
+        while queue:
+            current = queue.pop(0)
+            # Check in-edges on current (both qualified ID and bare name)
+            for src, _, data in self._g.nx_graph.in_edges(current, data=True):
+                if data.get("edge_type") != "CALLS":
+                    continue
+                if src in visited:
+                    continue
+                visited.add(src)
+                caller = self._g.get_node(src)
+                if isinstance(caller, FunctionNode):
+                    result[caller.id] = caller
+                    # Also expand bare name of caller to catch its own bare-name callers
+                    if caller.name not in visited:
+                        visited.add(caller.name)
+                        queue.append(caller.name)
+                queue.append(src)
+
+        return sorted(result.values(), key=lambda f: f.id)
+
+    # ------------------------------------------------------------------
+    # 12. Async functions
     # ------------------------------------------------------------------
 
     def async_functions(self) -> list[FunctionNode]:
@@ -420,7 +562,7 @@ class GraphQueries:
         )
 
     # ------------------------------------------------------------------
-    # 10. Subclasses (INHERITS edges)
+    # 13. Subclasses (INHERITS edges)
     # ------------------------------------------------------------------
 
     def subclasses(self, base_name: str) -> list[ClassNode]:
@@ -449,7 +591,7 @@ class GraphQueries:
         return sorted(result, key=lambda c: c.id)
 
     # ------------------------------------------------------------------
-    # 11. Functions with a given parameter type annotation
+    # 14. Functions with a given parameter type annotation
     # ------------------------------------------------------------------
 
     def functions_with_param_type(

--- a/ckg/store.py
+++ b/ckg/store.py
@@ -130,6 +130,7 @@ def _row_to_node(row: tuple) -> Node:
             class_name=props.get("class_name"),
             param_count=props.get("param_count", 0),
             params=params,
+            decorators=props.get("decorators", []),
         )
     if node_type == "class":
         return ClassNode(
@@ -141,6 +142,7 @@ def _row_to_node(row: tuple) -> Node:
             bases=props.get("bases", []),
             docstring=props.get("docstring"),
             method_count=props.get("method_count", 0),
+            decorators=props.get("decorators", []),
         )
     if node_type == "module":
         return ModuleNode(

--- a/tests/test_decorators_transitive.py
+++ b/tests/test_decorators_transitive.py
@@ -1,0 +1,437 @@
+"""Tests for decorator capture, transitive queries, and new CLI subcommands."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ckg.graph import PropertyGraph
+from ckg.models import FunctionNode, ClassNode
+from ckg.parsers.python import parse_file
+from ckg.queries import GraphQueries
+from ckg.store import GraphStore
+
+
+# ---------------------------------------------------------------------------
+# Test repo
+# ---------------------------------------------------------------------------
+
+def _make_repo(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    (tmp_path / "api.py").write_text(textwrap.dedent("""\
+        from fastapi import FastAPI
+        from typing import List
+
+        app = FastAPI()
+
+        @app.get("/items")
+        async def list_items() -> List[dict]:
+            \"\"\"List all items.\"\"\"
+            return []
+
+        @app.post("/items")
+        @app.get("/items/{item_id}")
+        async def get_item(item_id: int) -> dict:
+            return {}
+
+        def internal_helper():
+            pass
+    """))
+
+    (tmp_path / "cli.py").write_text(textwrap.dedent("""\
+        import click
+        from service import process, fetch
+
+        @click.group()
+        def main():
+            pass
+
+        @main.command()
+        @click.argument("name")
+        def run(name: str) -> None:
+            \"\"\"Run the command.\"\"\"
+            result = process(name)
+            return fetch(result)
+
+        @main.command()
+        def status() -> None:
+            pass
+    """))
+
+    (tmp_path / "service.py").write_text(textwrap.dedent("""\
+        from db import Database
+
+        def process(name: str) -> str:
+            db = Database()
+            db.save(name)
+            return name.upper()
+
+        def fetch(key: str) -> str:
+            return key
+    """))
+
+    (tmp_path / "db.py").write_text(textwrap.dedent("""\
+        class Database:
+            \"\"\"Simple DB.\"\"\"
+            def save(self, value: str) -> None:
+                pass
+
+            def load(self, key: str) -> str:
+                return key
+    """))
+
+    (tmp_path / "models.py").write_text(textwrap.dedent("""\
+        from pydantic import BaseModel
+
+        @staticmethod
+        def standalone():
+            pass
+
+        class Item(BaseModel):
+            name: str
+
+        @dataclass_decorator
+        class Config:
+            debug: bool = False
+    """))
+
+    return tmp_path
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    return _make_repo(tmp_path / "repo")
+
+
+@pytest.fixture()
+def graph(repo: Path) -> PropertyGraph:
+    g = PropertyGraph()
+    g.build_from_directory(repo)
+    return g
+
+
+@pytest.fixture()
+def queries(graph: PropertyGraph) -> GraphQueries:
+    return GraphQueries(graph)
+
+
+# ---------------------------------------------------------------------------
+# Parser — decorator capture on FunctionNode
+# ---------------------------------------------------------------------------
+
+class TestParserDecorators:
+    def test_single_decorator_captured(self, repo: Path) -> None:
+        result = parse_file(repo / "api.py", repo)
+        fn = next(f for f in result.functions if f.name == "list_items")
+        assert len(fn.decorators) == 1
+        assert "app.get" in fn.decorators[0]
+
+    def test_multiple_decorators_captured(self, repo: Path) -> None:
+        result = parse_file(repo / "api.py", repo)
+        fn = next(f for f in result.functions if f.name == "get_item")
+        assert len(fn.decorators) == 2
+
+    def test_click_decorator_captured(self, repo: Path) -> None:
+        result = parse_file(repo / "cli.py", repo)
+        fn = next(f for f in result.functions if f.name == "run")
+        dec_strs = " ".join(fn.decorators)
+        assert "main.command" in dec_strs
+        assert "click.argument" in dec_strs
+
+    def test_no_decorator_gives_empty_list(self, repo: Path) -> None:
+        result = parse_file(repo / "api.py", repo)
+        fn = next(f for f in result.functions if f.name == "internal_helper")
+        assert fn.decorators == []
+
+    def test_decorator_is_string(self, repo: Path) -> None:
+        result = parse_file(repo / "api.py", repo)
+        fn = next(f for f in result.functions if f.name == "list_items")
+        assert all(isinstance(d, str) for d in fn.decorators)
+
+    def test_decorator_contains_route_path(self, repo: Path) -> None:
+        result = parse_file(repo / "api.py", repo)
+        fn = next(f for f in result.functions if f.name == "list_items")
+        assert "/items" in fn.decorators[0]
+
+
+# ---------------------------------------------------------------------------
+# Parser — decorator capture on ClassNode
+# ---------------------------------------------------------------------------
+
+class TestParserClassDecorators:
+    def test_class_decorator_captured(self, repo: Path) -> None:
+        result = parse_file(repo / "models.py", repo)
+        cls = next(c for c in result.classes if c.name == "Config")
+        assert "dataclass_decorator" in cls.decorators[0]
+
+    def test_class_without_decorator_empty(self, repo: Path) -> None:
+        result = parse_file(repo / "models.py", repo)
+        cls = next(c for c in result.classes if c.name == "Item")
+        assert cls.decorators == []
+
+
+# ---------------------------------------------------------------------------
+# Store round-trip — decorators
+# ---------------------------------------------------------------------------
+
+class TestStoreDecoratorsRoundTrip:
+    def test_function_decorators_survive(self, repo: Path, tmp_path: Path) -> None:
+        store = GraphStore(tmp_path / "g.db")
+        store.build_and_save(repo)
+        g = store.load()
+
+        fn = g.get_node("api.py::list_items")
+        assert isinstance(fn, FunctionNode)
+        assert len(fn.decorators) == 1
+        assert "app.get" in fn.decorators[0]
+
+    def test_multiple_decorators_survive(self, repo: Path, tmp_path: Path) -> None:
+        store = GraphStore(tmp_path / "g.db")
+        store.build_and_save(repo)
+        g = store.load()
+
+        fn = g.get_node("api.py::get_item")
+        assert isinstance(fn, FunctionNode)
+        assert len(fn.decorators) == 2
+
+    def test_empty_decorators_survive(self, repo: Path, tmp_path: Path) -> None:
+        store = GraphStore(tmp_path / "g.db")
+        store.build_and_save(repo)
+        g = store.load()
+
+        fn = g.get_node("api.py::internal_helper")
+        assert isinstance(fn, FunctionNode)
+        assert fn.decorators == []
+
+    def test_class_decorators_survive(self, repo: Path, tmp_path: Path) -> None:
+        store = GraphStore(tmp_path / "g.db")
+        store.build_and_save(repo)
+        g = store.load()
+
+        cls = g.get_node("models.py::Config")
+        assert isinstance(cls, ClassNode)
+        assert any("dataclass_decorator" in d for d in cls.decorators)
+
+
+# ---------------------------------------------------------------------------
+# GraphQueries — functions_with_decorator
+# ---------------------------------------------------------------------------
+
+class TestFunctionsWithDecorator:
+    def test_finds_app_get_routes(self, queries: GraphQueries) -> None:
+        fns = queries.functions_with_decorator("app.get")
+        ids = [f.id for f in fns]
+        assert "api.py::list_items" in ids
+        assert "api.py::get_item" in ids
+
+    def test_finds_click_commands(self, queries: GraphQueries) -> None:
+        fns = queries.functions_with_decorator("command")
+        ids = [f.id for f in fns]
+        assert "cli.py::run" in ids
+        assert "cli.py::status" in ids
+
+    def test_excludes_undecorated(self, queries: GraphQueries) -> None:
+        fns = queries.functions_with_decorator("app.get")
+        ids = [f.id for f in fns]
+        assert "api.py::internal_helper" not in ids
+        assert "service.py::process" not in ids
+
+    def test_substring_match(self, queries: GraphQueries) -> None:
+        # "app" matches both "app.get" and "app.post"
+        fns = queries.functions_with_decorator("app.")
+        assert len(fns) >= 2
+
+    def test_exact_match(self, queries: GraphQueries) -> None:
+        # Only "app.get('/items')" should match exactly
+        fns = queries.functions_with_decorator(
+            "app.get('/items')", substring=False
+        )
+        assert len(fns) == 1
+        assert fns[0].id == "api.py::list_items"
+
+    def test_no_match_returns_empty(self, queries: GraphQueries) -> None:
+        assert queries.functions_with_decorator("nonexistent_decorator") == []
+
+    def test_each_function_appears_once(self, queries: GraphQueries) -> None:
+        # get_item has two decorators matching "app." — should appear only once
+        fns = queries.functions_with_decorator("app.")
+        ids = [f.id for f in fns]
+        assert len(ids) == len(set(ids))
+
+    def test_sorted_by_id(self, queries: GraphQueries) -> None:
+        fns = queries.functions_with_decorator("app.")
+        ids = [f.id for f in fns]
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# GraphQueries — transitive_deps
+# ---------------------------------------------------------------------------
+
+class TestTransitiveDeps:
+    def test_cli_sees_service_and_db(self, queries: GraphQueries) -> None:
+        deps = queries.transitive_deps("cli.py")
+        # cli imports service, service imports db
+        assert "service" in deps or "service.py" in deps
+        assert "db" in deps or "db.py" in deps
+
+    def test_direct_import_included(self, queries: GraphQueries) -> None:
+        deps = queries.transitive_deps("cli.py")
+        # cli directly imports click
+        assert "click" in deps
+
+    def test_excludes_self(self, queries: GraphQueries) -> None:
+        deps = queries.transitive_deps("cli.py")
+        assert "cli.py" not in deps
+        assert "cli" not in deps
+
+    def test_nonexistent_file_returns_empty(self, queries: GraphQueries) -> None:
+        deps = queries.transitive_deps("nonexistent.py")
+        assert deps == set()
+
+    def test_leaf_file_has_only_direct_deps(self, queries: GraphQueries) -> None:
+        # db.py imports nothing
+        deps = queries.transitive_deps("db.py")
+        # may be empty or just stdlib
+        assert "cli.py" not in deps
+
+    def test_returns_set(self, queries: GraphQueries) -> None:
+        result = queries.transitive_deps("cli.py")
+        assert isinstance(result, set)
+
+
+# ---------------------------------------------------------------------------
+# GraphQueries — transitive_callers
+# ---------------------------------------------------------------------------
+
+class TestTransitiveCallers:
+    def test_finds_direct_caller(self, queries: GraphQueries) -> None:
+        # process() is called by run()
+        callers = queries.transitive_callers("service.py::process")
+        ids = [f.id for f in callers]
+        assert "cli.py::run" in ids
+
+    def test_finds_indirect_callers(self, queries: GraphQueries) -> None:
+        # fetch() is called by run(); run itself has no callers
+        # so transitive callers of fetch should include run
+        callers = queries.transitive_callers("service.py::fetch")
+        ids = [f.id for f in callers]
+        # run calls fetch directly
+        assert "cli.py::run" in ids
+
+    def test_no_callers_returns_empty(self, queries: GraphQueries) -> None:
+        # list_items is an endpoint — nothing calls it
+        callers = queries.transitive_callers("api.py::list_items")
+        assert callers == []
+
+    def test_returns_function_nodes_only(self, queries: GraphQueries) -> None:
+        callers = queries.transitive_callers("service.py::process")
+        assert all(isinstance(f, FunctionNode) for f in callers)
+
+    def test_no_duplicates(self, queries: GraphQueries) -> None:
+        callers = queries.transitive_callers("service.py::process")
+        ids = [f.id for f in callers]
+        assert len(ids) == len(set(ids))
+
+    def test_sorted_by_id(self, queries: GraphQueries) -> None:
+        callers = queries.transitive_callers("service.py::process")
+        ids = [f.id for f in callers]
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# CLI — new subcommands
+# ---------------------------------------------------------------------------
+
+class TestNewCLISubcommands:
+    def _build_db(self, tmp_path: Path) -> tuple[Path, Path]:
+        repo = _make_repo(tmp_path / "repo")
+        db = tmp_path / "g.db"
+        GraphStore(db).build_and_save(repo)
+        return repo, db
+
+    def test_decorator_command_finds_routes(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "query", "decorator", "app.get",
+                  "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "list_items" in result.output
+        assert "get_item" in result.output
+
+    def test_decorator_command_no_match(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "query", "decorator", "nonexistent",
+                  "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "No functions" in result.output
+
+    def test_transitive_deps_command(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "query", "transitive-deps", "cli.py",
+                  "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # Should show total count and some dependency names
+        assert "Transitive dependencies" in result.output
+        assert "service" in result.output or "click" in result.output
+
+    def test_transitive_callers_command(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "query", "transitive-callers",
+                  "service.py::process", "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "run" in result.output
+
+    def test_inspect_node_shows_decorators(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "inspect", "node", "api.py::list_items",
+                  "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "Decorators" in result.output
+        assert "app.get" in result.output
+
+    def test_inspect_node_no_decorators_row_absent(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+        from ckg.cli import cli
+        repo, db = self._build_db(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--db", str(db), "inspect", "node", "api.py::internal_helper",
+                  "--repo", str(repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # No decorators → row should not appear
+        assert "Decorators" not in result.output


### PR DESCRIPTION
## Summary

Two high-value features for framework-heavy Python codebases: decorator capture (making FastAPI routes, Click commands, pytest marks visible to the graph) and transitive queries (full import closure + unbounded call chain traversal).

## Decorator capture

**Model:** `FunctionNode.decorators: list[str]` and `ClassNode.decorators: list[str]` — `ast.unparse()` of each decorator expression.

**Parser:** one line per node type — `[ast.unparse(d) for d in node.decorator_list]`.

**Store:** serialised as JSON array in properties blob; reconstructed on load.

### New query
```python
queries.functions_with_decorator("app.get")          # FastAPI routes
queries.functions_with_decorator("click.command")    # Click commands
queries.functions_with_decorator("pytest.mark")      # marked tests
queries.functions_with_decorator("staticmethod", substring=False)
```

### New CLI
```bash
ckg query decorator "app.get"        # → 4 FastAPI GET routes on P³
ckg query decorator "main.command"   # → 15 Click commands on P³
```

`ckg inspect node` now shows a **Decorators** row when present.

## Transitive queries

### `transitive_deps(file_path)` — full import closure
```bash
ckg query transitive-deps cli.py
# → 40 total: 8 local files + 32 external/stdlib (P³)
```
Bridges `ModuleNode("service") → FileNode("service.py")` so the BFS crosses file-to-module boundaries correctly (pure `nx.descendants` would stop at the module node).

### `transitive_callers(node_id)` — unbounded upstream BFS
```bash
ckg query transitive-callers add_episode
# → process_feed + fetch_all_feeds (P³)
```
Unlike `impact_radius(depth=3)`, this returns the full upstream call chain with no depth limit. Follows bare-name CALLS edges (same resolution as `callers()`).

## Tests

38 new tests + 305 existing = **343 total, all passing**

Coverage:
- Parser: single/multiple decorators, click decorators, no decorator, decorator is string, route path in decorator
- Class decorators: decorated class captured, undecorated class empty
- Store round-trip: function + class decorators survive, empty list survives
- `functions_with_decorator`: finds routes, clicks, excludes undecorated, substring/exact match, no match, each fn once, sorted
- `transitive_deps`: cli sees service+db, direct import, excludes self, nonexistent → empty, leaf has only direct, returns set
- `transitive_callers`: direct caller, indirect caller, no callers → empty, FunctionNode only, no duplicates, sorted
- CLI: decorator finds/no-match, transitive-deps, transitive-callers, inspect shows/hides decorators row